### PR TITLE
Vlasov maxwell bugfix

### DIFF
--- a/src/struphy/models/vlasov_ampere_one_species.py
+++ b/src/struphy/models/vlasov_ampere_one_species.py
@@ -99,7 +99,7 @@ class VlasovAmpereOneSpecies(StruphyModel):
         if MPI.COMM_WORLD.Get_rank() == 0:
             print("\nINITIAL POISSON SOLVE:")
 
-        # use control variate method
+        # use control variate method (reset weights after Poisson solve)
         particles = self.kinetic_ions.var.particles
         particles.update_weights()
 
@@ -135,6 +135,9 @@ class VlasovAmpereOneSpecies(StruphyModel):
         Propagator.derham.grad.dot(-phi, out=self.em_fields.e_field.spline.vector)
         if MPI.COMM_WORLD.Get_rank() == 0 and verbose:
             print("... Done.")
+
+        # reset particle weights
+        particles.weights = particles.weights_at_t0.copy()
 
     def update_scalar_quantities(self):
         # e*M1*e/2

--- a/src/struphy/models/vlasov_maxwell_one_species.py
+++ b/src/struphy/models/vlasov_maxwell_one_species.py
@@ -179,8 +179,7 @@ class VlasovMaxwellOneSpecies(StruphyModel):
         particles.update_weights()
 
         # sanity check
-        # self.pointer['species1'].show_distribution_function(
-        #     [True] + [False]*5, [xp.linspace(0, 1, 32)])
+        # particles.show_distribution_function([True] + [False]*5, [xp.linspace(0, 1, 32)])
 
         # accumulate charge density
         charge_accum = AccumulatorVector(
@@ -210,6 +209,9 @@ class VlasovMaxwellOneSpecies(StruphyModel):
         Propagator.derham.grad.dot(-phi, out=self.em_fields.e_field.spline.vector)
         if MPI.COMM_WORLD.Get_rank() == 0 and verbose:
             print("... Done.")
+            
+        # reset particle weights
+        particles.weights = particles.weights_at_t0.copy()
 
     def update_scalar_quantities(self):
         # e*M1*e/2
@@ -235,6 +237,7 @@ class VlasovMaxwellOneSpecies(StruphyModel):
                 particles.markers_wo_holes[:, 6],
             )
         )
+        
         self.update_scalar("en_f", self._tmp[0])
 
         # en_tot = en_w + en_e

--- a/src/struphy/models/vlasov_maxwell_one_species.py
+++ b/src/struphy/models/vlasov_maxwell_one_species.py
@@ -209,7 +209,7 @@ class VlasovMaxwellOneSpecies(StruphyModel):
         Propagator.derham.grad.dot(-phi, out=self.em_fields.e_field.spline.vector)
         if MPI.COMM_WORLD.Get_rank() == 0 and verbose:
             print("... Done.")
-            
+
         # reset particle weights
         particles.weights = particles.weights_at_t0.copy()
 
@@ -237,7 +237,7 @@ class VlasovMaxwellOneSpecies(StruphyModel):
                 particles.markers_wo_holes[:, 6],
             )
         )
-        
+
         self.update_scalar("en_f", self._tmp[0])
 
         # en_tot = en_w + en_e

--- a/src/struphy/models/vlasov_maxwell_one_species.py
+++ b/src/struphy/models/vlasov_maxwell_one_species.py
@@ -174,7 +174,7 @@ class VlasovMaxwellOneSpecies(StruphyModel):
         if MPI.COMM_WORLD.Get_rank() == 0:
             print("\nINITIAL POISSON SOLVE:")
 
-        # use control variate method
+        # use control variate method (reset weights after Poisson solve)
         particles = self.kinetic_ions.var.particles
         particles.update_weights()
 

--- a/src/struphy/pic/base.py
+++ b/src/struphy/pic/base.py
@@ -825,6 +825,11 @@ class Particles(metaclass=ABCMeta):
         assert isinstance(new, xp.ndarray)
         assert new.shape == (self.n_mks_loc,)
         self._markers[self.valid_mks, self.index["weights"]] = new
+        
+    @property
+    def weights_at_t0(self):
+        """Array holding the initial marker weights. The i-th row holds the i-th marker info."""
+        return self.markers[self.valid_mks, self.index["w0"]]
 
     @property
     def sampling_density(self):

--- a/src/struphy/pic/base.py
+++ b/src/struphy/pic/base.py
@@ -825,7 +825,7 @@ class Particles(metaclass=ABCMeta):
         assert isinstance(new, xp.ndarray)
         assert new.shape == (self.n_mks_loc,)
         self._markers[self.valid_mks, self.index["weights"]] = new
-        
+
     @property
     def weights_at_t0(self):
         """Array holding the initial marker weights. The i-th row holds the i-th marker info."""


### PR DESCRIPTION
The weights in models with an initial Poisson solve are set to zero for noise reduction (automatic control variate). In runs without control variate, they must be restored after the initial Poisson solve. 