### PR TITLE
Generate parameter files from Simulation class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     'pytest',
     'pytest-mpi',
     'pytest-testmon',
+    'ruff>=0.15.0',
     'line_profiler',
     'scope-profiler>=0.1.7',
 ]
@@ -60,7 +61,6 @@ dev = [
     "pylint",
     "ssort",
     "add-trailing-comma",
-    "ruff>=0.15.0",
     "pre-commit",
     "nbstripout",
     "tabulate",

--- a/src/struphy/fields_background/base.py
+++ b/src/struphy/fields_background/base.py
@@ -7,7 +7,11 @@ from matplotlib import pyplot as plt
 from pyevtk.hl import gridToVTK
 
 from struphy.geometry.base import Domain
-from struphy.utils.utils import __class_with_params_repr_no_defaults__, __dataclass_repr_no_defaults__
+from struphy.utils.utils import (
+    __class_with_params_repr_no_defaults__,
+    __dataclass_repr_no_defaults__,
+    all_class_params_are_default,
+)
 
 
 class FluidEquilibrium(metaclass=ABCMeta):
@@ -113,6 +117,10 @@ class FluidEquilibrium(metaclass=ABCMeta):
 
     def __repr_no_defaults__(self):
         return __class_with_params_repr_no_defaults__(self)
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     ###########################
     # Vector-valued callables #

--- a/src/struphy/fields_background/base.py
+++ b/src/struphy/fields_background/base.py
@@ -7,6 +7,7 @@ from matplotlib import pyplot as plt
 from pyevtk.hl import gridToVTK
 
 from struphy.geometry.base import Domain
+from struphy.utils.utils import __class_with_params_repr_no_defaults__, __dataclass_repr_no_defaults__
 
 
 class FluidEquilibrium(metaclass=ABCMeta):
@@ -96,12 +97,22 @@ class FluidEquilibrium(metaclass=ABCMeta):
         assert isinstance(new_domain, Domain) or new_domain is None
         self._domain = new_domain
 
-    def __repr__(self):
+    def __str__(self):
         out = f"{self.__class__.__name__}"
         for k, v in self.params.items():
             out += f"\n    {k}:".ljust(20)
             out += f"{v}"
         return out
+
+    def __repr__(self) -> str:
+        out = f"{self.__class__.__name__}("
+        for k, v in self.params.items():
+            out += f"{k}={v}, "
+        out += ")"
+        return out
+
+    def __repr_no_defaults__(self):
+        return __class_with_params_repr_no_defaults__(self)
 
     ###########################
     # Vector-valued callables #

--- a/src/struphy/fields_background/equils.py
+++ b/src/struphy/fields_background/equils.py
@@ -35,7 +35,7 @@ from struphy.fields_background.base import (
 from struphy.fields_background.mhd_equil.eqdsk import readeqdsk
 from struphy.io.options import BaseUnits
 from struphy.physics.physics import Units
-from struphy.utils.utils import read_state, subp_run
+from struphy.utils.utils import all_class_params_are_default, read_state, subp_run
 
 if TYPE_CHECKING:
     from struphy import domains

--- a/src/struphy/geometry/base.py
+++ b/src/struphy/geometry/base.py
@@ -13,7 +13,7 @@ import struphy.bsplines.bsplines as bsp
 from struphy.geometry import evaluation_kernels, transform_kernels
 from struphy.kernel_arguments.pusher_args_kernels import DomainArguments
 from struphy.linear_algebra import linalg_kron
-from struphy.utils.utils import __class_with_params_repr_no_defaults__
+from struphy.utils.utils import __class_with_params_repr_no_defaults__, all_class_params_are_default
 
 
 class Domain(metaclass=ABCMeta):
@@ -219,6 +219,10 @@ class Domain(metaclass=ABCMeta):
 
     def __repr_no_defaults__(self):
         return __class_with_params_repr_no_defaults__(self)
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     def __str__(self):
         print(f"{self.__class__.__name__}")

--- a/src/struphy/geometry/base.py
+++ b/src/struphy/geometry/base.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 "Base classes for mapped domains (single patch)."
 
+import inspect
 from abc import ABCMeta, abstractmethod
 
 import cunumpy as xp
@@ -12,6 +13,7 @@ import struphy.bsplines.bsplines as bsp
 from struphy.geometry import evaluation_kernels, transform_kernels
 from struphy.kernel_arguments.pusher_args_kernels import DomainArguments
 from struphy.linear_algebra import linalg_kron
+from struphy.utils.utils import __class_with_params_repr_no_defaults__
 
 
 class Domain(metaclass=ABCMeta):
@@ -209,6 +211,16 @@ class Domain(metaclass=ABCMeta):
         )
 
     def __repr__(self):
+        out = f"{self.__class__.__name__}("
+        for k, v in self.params.items():
+            out += f"{k}={v}, "
+        out += ")"
+        return out
+
+    def __repr_no_defaults__(self):
+        return __class_with_params_repr_no_defaults__(self)
+
+    def __str__(self):
         print(f"{self.__class__.__name__}")
         for k, v in self.params.items():
             print(f"{k}:".ljust(20), v)

--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from struphy.utils.utils import __dataclass_repr_no_defaults__, check_option
+from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params_are_default, check_option
 
 
 @dataclass
@@ -138,6 +138,10 @@ class Time:
     def __repr_no_defaults__(self):
         return __dataclass_repr_no_defaults__(self)
 
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
+
     def to_dict(self) -> dict:
         dct = {
             "dt": self.dt,
@@ -188,6 +192,10 @@ class BaseUnits:
 
     def __repr_no_defaults__(self):
         return __dataclass_repr_no_defaults__(self)
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     def to_dict(self) -> dict:
         dct = {
@@ -255,6 +263,10 @@ class DerhamOptions:
     def __repr_no_defaults__(self):
         return __dataclass_repr_no_defaults__(self)
 
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
+
     def to_dict(self) -> dict:
         dct = {
             "p": self.p,
@@ -311,6 +323,10 @@ class FieldsBackground:
 
     def __repr_no_defaults__(self):
         return __dataclass_repr_no_defaults__(self)
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     def to_dict(self) -> dict:
         dct = {
@@ -385,6 +401,10 @@ class EnvironmentOptions:
 
     def __repr_no_defaults__(self):
         return __dataclass_repr_no_defaults__(self)
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     def to_dict(self) -> dict:
         dct = {

--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from struphy.utils.utils import check_option
+from struphy.utils.utils import __dataclass_repr_no_defaults__, check_option
 
 
 @dataclass
@@ -130,10 +130,13 @@ class Time:
     def __post_init__(self):
         check_option(self.split_algo, LiteralOptions.SplitAlgos)
 
-    def __repr__(self):
+    def __str__(self):
         for k, v in self.__dict__.items():
             print(f"{k}:".ljust(20), v)
         return ""
+
+    def __repr_no_defaults__(self):
+        return __dataclass_repr_no_defaults__(self)
 
     def to_dict(self) -> dict:
         dct = {
@@ -177,11 +180,14 @@ class BaseUnits:
     n: float = 1.0
     kBT: float = None
 
-    def __repr__(self):
+    def __str__(self):
         units = ["m", "T", "1e20/m^3", "keV"]
         for (k, v), unit in zip(self.__dict__.items(), units):
             print(f"{k}:".ljust(20), v, unit)
         return ""
+
+    def __repr_no_defaults__(self):
+        return __dataclass_repr_no_defaults__(self)
 
     def to_dict(self) -> dict:
         dct = {
@@ -241,10 +247,13 @@ class DerhamOptions:
     def __post_init__(self):
         check_option(self.polar_ck, LiteralOptions.PolarRegularity)
 
-    def __repr__(self):
+    def __str__(self):
         for k, v in self.__dict__.items():
             print(f"{k}:".ljust(20), v)
         return ""
+
+    def __repr_no_defaults__(self):
+        return __dataclass_repr_no_defaults__(self)
 
     def to_dict(self) -> dict:
         dct = {
@@ -295,10 +304,13 @@ class FieldsBackground:
     def __post_init__(self):
         check_option(self.type, LiteralOptions.BackgroundTypes)
 
-    def __repr__(self):
+    def __str__(self):
         for k, v in self.__dict__.items():
             print(f"{k}:".ljust(20), v)
         return ""
+
+    def __repr_no_defaults__(self):
+        return __dataclass_repr_no_defaults__(self)
 
     def to_dict(self) -> dict:
         dct = {
@@ -366,10 +378,13 @@ class EnvironmentOptions:
     def __post_init__(self):
         self.path_out: str = os.path.join(self.out_folders, self.sim_folder)
 
-    def __repr__(self):
+    def __str__(self):
         for k, v in self.__dict__.items():
             print(f"{k}:".ljust(20), v)
         return ""
+
+    def __repr_no_defaults__(self):
+        return __dataclass_repr_no_defaults__(self)
 
     def to_dict(self) -> dict:
         dct = {

--- a/src/struphy/models/base.py
+++ b/src/struphy/models/base.py
@@ -16,6 +16,7 @@ from struphy.pic.base import Particles
 from struphy.propagators.base import Propagator
 from struphy.utils.clone_config import CloneConfig
 from struphy.utils.docstring_converter import rst_to_markdown
+from struphy.utils.utils import all_class_params_are_default
 
 
 class StruphyModel(metaclass=ABCMeta):
@@ -152,6 +153,10 @@ class StruphyModel(metaclass=ABCMeta):
 
     def __repr_no_defaults__(self) -> str:
         return self.__repr__()
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     def __str__(self):
         out = f"{self.__class__.__name__}\n"

--- a/src/struphy/models/base.py
+++ b/src/struphy/models/base.py
@@ -147,7 +147,13 @@ class StruphyModel(metaclass=ABCMeta):
     # --------------
     # Common methods
     # --------------
-    def __repr__(self):
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
+    def __repr_no_defaults__(self) -> str:
+        return self.__repr__()
+
+    def __str__(self):
         out = f"{self.__class__.__name__}\n"
         for k, v in self.species.items():
             out += f"    {k}:\n"

--- a/src/struphy/models/tests/utils_testing.py
+++ b/src/struphy/models/tests/utils_testing.py
@@ -69,6 +69,11 @@ def call_test(model: StruphyModel, test_profiling: bool = False, verbose: bool =
     sim2 = Simulation.from_dict(sim_dict)  # test the from_dict method
     assert sim == sim2, "Simulation to_dict and from_dict methods are not consistent"
 
+    # test the generate_script method
+    sim1_script = sim.generate_script()
+    sim2_script = sim2.generate_script()
+    assert sim1_script == sim2_script
+
     sim.show_parameters()
 
     sim.run(verbose=verbose)

--- a/src/struphy/models/tests/utils_testing.py
+++ b/src/struphy/models/tests/utils_testing.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import shutil
+import tempfile
 from types import ModuleType
 
 from feectools.ddm.mpi import mpi as MPI
@@ -73,6 +74,21 @@ def call_test(model: StruphyModel, test_profiling: bool = False, verbose: bool =
     sim1_script = sim.generate_script()
     sim2_script = sim2.generate_script()
     assert sim1_script == sim2_script
+
+    # Save the generated script to a file and check that it can be imported and run
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as tmp:
+        sim.save_script(tmp.name, include_main_guard=True)
+        tmp.seek(0)
+        spec = import_parameters_py(tmp.name)
+        assert isinstance(spec, ModuleType), "Generated script did not import as a module"
+        assert hasattr(spec, "sim"), "Generated script does not have a 'sim' object"
+        assert isinstance(spec.sim, Simulation), "'sim' object in generated script is not a Simulation instance"
+        assert sim.generate_script() == spec.sim.generate_script(), (
+            "Generated script does not match original simulation"
+        )
+        assert sim == spec.sim, "Simulation in generated script is not the same as the original simulation"
+
+        # Run the simulation from the generated script
 
     sim.show_parameters()
 

--- a/src/struphy/post_processing/post_processing_tools.py
+++ b/src/struphy/post_processing/post_processing_tools.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class SplineValues:
-    def __repr__(self):
+    def __str__(self):
         out = ""
         for name, species in inspect.getmembers(self):
             if isinstance(species, SpecHolder):
@@ -43,7 +43,7 @@ class SplineValues:
 
 
 class Orbits:
-    def __repr__(self):
+    def __str__(self):
         out = ""
         for species, orbits in self.__dict__.items():
             shp = orbits.shape
@@ -55,7 +55,7 @@ class Orbits:
 
 
 class DistributionFunction:
-    def __repr__(self):
+    def __str__(self):
         out = ""
         for name, species in inspect.getmembers(self):
             if isinstance(species, SpecHolder):
@@ -65,7 +65,7 @@ class DistributionFunction:
 
 
 class DensitySPH:
-    def __repr__(self):
+    def __str__(self):
         out = ""
         for name, species in inspect.getmembers(self):
             if isinstance(species, SpecHolder):
@@ -75,7 +75,7 @@ class DensitySPH:
 
 
 class SpecHolder:
-    def __repr__(self):
+    def __str__(self):
         out = ""
         for name, val in self.__dict__.items():
             out += f"        {name}\n"
@@ -90,7 +90,7 @@ class DataDict:
     def __init__(self, data: dict):
         self.data = data
 
-    def __repr__(self):
+    def __str__(self):
         out = f"{type(self.data) = }\n"
         out += f"{len(self.data) = }\n"
         for key, d in self.data.items():

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1436,8 +1436,11 @@ model = {self.model.__repr__()}
 env = {self.env.__repr_no_defaults__()}
 base_units = {self.base_units.__repr_no_defaults__()}
 time_opts = {self.time_opts.__repr_no_defaults__()}
-domain = domains.{self.domain.__repr_no_defaults__()}
-equil = equils.{self.equil.__repr_no_defaults__()}
+domain = domains.{self.domain.__repr_no_defaults__()}"""
+        if self.equil is not None:
+            script += f"""
+equil = equils.{self.equil.__repr_no_defaults__()}"""
+        script += f"""
 grid = grids.{self.grid.__repr_no_defaults__()}
 derham_opts = {self.derham_opts.__repr_no_defaults__()}
 
@@ -1448,8 +1451,11 @@ sim = Simulation(
     env=env,
     base_units=base_units,
     time_opts=time_opts,
-    domain=domain,
-    equil=equil,
+    domain=domain,"""
+        if self.equil is not None:
+            script += """
+    equil=equil,"""
+        script += """
     grid=grid,
     derham_opts=derham_opts,
 )

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1412,6 +1412,7 @@ RESTARTing from:
 
     def generate_script(self) -> str:
         """Generate a Python script that can be used to reproduce the simulation."""
+
         script = f"""
 from struphy import (
     BaseUnits,
@@ -1432,35 +1433,40 @@ from struphy import (
 
 from struphy.models import {self.model.__class__.__name__}
 
-model = {self.model.__repr__()}
-env = {self.env.__repr_no_defaults__()}
-base_units = {self.base_units.__repr_no_defaults__()}
-time_opts = {self.time_opts.__repr_no_defaults__()}
-domain = domains.{self.domain.__repr_no_defaults__()}"""
-        if self.equil is not None:
-            script += f"""
-equil = equils.{self.equil.__repr_no_defaults__()}"""
-        script += f"""
-grid = grids.{self.grid.__repr_no_defaults__()}
-derham_opts = {self.derham_opts.__repr_no_defaults__()}
+"""
 
+        sim_setup = f"model = {self.model.__repr_no_defaults__()}\n"
+        sim_class_def = "sim = Simulation("
 
-sim = Simulation(
-    model=model,
-    params_path={repr(self.params_path)},
-    env=env,
-    base_units=base_units,
-    time_opts=time_opts,
-    domain=domain,"""
-        if self.equil is not None:
-            script += """
-    equil=equil,"""
+        if not self.env.is_default:
+            sim_setup += f"env = {self.env.__repr_no_defaults__()}\n"
+            sim_class_def += "env=env,"
+        if not self.base_units.is_default:
+            sim_setup += f"base_units = {self.base_units.__repr_no_defaults__()}\n"
+            sim_class_def += "base_units=base_units,"
+        if not self.time_opts.is_default:
+            sim_setup += f"time_opts = {self.time_opts.__repr_no_defaults__()}\n"
+            sim_class_def += "time_opts=time_opts,"
+        if not self.domain.is_default:
+            sim_setup += f"domain = domains.{self.domain.__repr_no_defaults__()}\n"
+            sim_class_def += "domain=domain,"
+        if self.equil is not None and not self.equil.is_default:
+            sim_setup += f"equil = equils.{self.equil.__repr_no_defaults__()}\n"
+            sim_class_def += "equil=equil,"
+        if not self.grid.is_default:
+            sim_setup += f"grid = grids.{self.grid.__repr_no_defaults__()}\n"
+            sim_class_def += "grid=grid,"
+        if not self.derham_opts.is_default:
+            sim_setup += f"derham_opts = {self.derham_opts.__repr_no_defaults__()}\n"
+            sim_class_def += "derham_opts=derham_opts,"
+        sim_class_def += ")\n"
+
+        script += sim_setup + "\n" + sim_class_def
+
         script += """
-    grid=grid,
-    derham_opts=derham_opts,
-)
-sim.run()
-        """
+if __name__ == "__main__":
+    sim.run()
+"""
         return script
 
     def __eq__(self, value: "Simulation") -> bool:

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1410,6 +1410,53 @@ RESTARTing from:
             verbose=dct.get("verbose", False),
         )
 
+    def generate_script(self) -> str:
+        """Generate a Python script that can be used to reproduce the simulation."""
+        script = f"""
+from struphy import (
+    BaseUnits,
+    DerhamOptions,
+    EnvironmentOptions,
+    FieldsBackground,
+    Simulation,
+    Time,
+    domains,
+    equils,
+    grids,
+    perturbations,
+)
+
+# ---------------------
+# Instance of the model
+# ---------------------
+
+from struphy.models import {self.model.__class__.__name__}
+
+model = {self.model.__repr__()}
+env = {self.env.__repr_no_defaults__()}
+base_units = {self.base_units.__repr_no_defaults__()}
+time_opts = {self.time_opts.__repr_no_defaults__()}
+domain = domains.{self.domain.__repr_no_defaults__()}
+equil = equils.{self.equil.__repr_no_defaults__()}
+grid = grids.{self.grid.__repr_no_defaults__()}
+derham_opts = {self.derham_opts.__repr_no_defaults__()}
+
+
+sim = Simulation(
+    model=model,
+    params_path={repr(self.params_path)},
+    env=env,
+    base_units=base_units,
+    time_opts=time_opts,
+    domain=domain,
+    equil=equil,
+    grid=grid,
+    derham_opts=derham_opts,
+)
+sim.run()
+        """
+        return script
+
     def __eq__(self, value: "Simulation") -> bool:
         assert isinstance(value, Simulation), "Comparison only implemented between Simulation instances."
         return self.to_dict() == value.to_dict()

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1410,7 +1410,7 @@ RESTARTing from:
             verbose=dct.get("verbose", False),
         )
 
-    def generate_script(self) -> str:
+    def generate_script(self, include_main_guard: bool = False) -> str:
         """Generate a Python script that can be used to reproduce the simulation."""
 
         script = f"""
@@ -1460,11 +1460,14 @@ from struphy.models import {self.model.__class__.__name__}
         if not self.derham_opts.is_default:
             sim_setup += f"derham_opts = {self.derham_opts.__repr_no_defaults__()}\n"
             sim_class_def += "derham_opts=derham_opts,"
+        if self.params_path is not None:
+            sim_class_def += f"params_path={repr(self.params_path)},\n"
+
         sim_class_def += ")\n"
 
         script += sim_setup + "\n" + sim_class_def
-
-        script += """
+        if include_main_guard:
+            script += """
 if __name__ == "__main__":
     sim.run()"""
 

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1473,6 +1473,16 @@ if __name__ == "__main__":
 
         return ruff_autofix_and_format(script)
 
+    def save_script(
+        self,
+        file_path: str,
+        include_main_guard: bool = False,
+    ):
+        """Save the generated script to a file."""
+        script = self.generate_script(include_main_guard=include_main_guard)
+        with open(file_path, "w") as f:
+            f.write(script)
+
     def __eq__(self, value: "Simulation") -> bool:
         assert isinstance(value, Simulation), "Comparison only implemented between Simulation instances."
         return self.to_dict() == value.to_dict()

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1435,9 +1435,14 @@ from struphy.models import {self.model.__class__.__name__}
 
 """
 
-        sim_setup = f"model = {self.model.__repr_no_defaults__()}\n"
+        sim_setup = ""
         sim_class_def = "sim = Simulation("
+        
+        # Always include model
+        sim_setup += f"model = {self.model.__repr_no_defaults__()}\n"
+        sim_class_def += "model=model,"
 
+        # Only include parameters that are not default to avoid cluttering the script with unnecessary lines
         if not self.env.is_default:
             sim_setup += f"env = {self.env.__repr_no_defaults__()}\n"
             sim_class_def += "env=env,"

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -61,7 +61,7 @@ from struphy.pic.base import Particles
 from struphy.propagators.base import Propagator
 from struphy.simulation.base import SimulationBase
 from struphy.utils.clone_config import CloneConfig
-from struphy.utils.utils import dict_to_yaml
+from struphy.utils.utils import dict_to_yaml, ruff_autofix_and_format
 
 
 class Simulation(SimulationBase):
@@ -1427,17 +1427,13 @@ from struphy import (
     perturbations,
 )
 
-# ---------------------
-# Instance of the model
-# ---------------------
-
 from struphy.models import {self.model.__class__.__name__}
 
 """
 
         sim_setup = ""
         sim_class_def = "sim = Simulation("
-        
+
         # Always include model
         sim_setup += f"model = {self.model.__repr_no_defaults__()}\n"
         sim_class_def += "model=model,"
@@ -1470,9 +1466,9 @@ from struphy.models import {self.model.__class__.__name__}
 
         script += """
 if __name__ == "__main__":
-    sim.run()
-"""
-        return script
+    sim.run()"""
+
+        return ruff_autofix_and_format(script)
 
     def __eq__(self, value: "Simulation") -> bool:
         assert isinstance(value, Simulation), "Comparison only implemented between Simulation instances."

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1451,7 +1451,8 @@ from struphy.models import {self.model.__class__.__name__}
         if not self.domain.is_default:
             sim_setup += f"domain = domains.{self.domain.__repr_no_defaults__()}\n"
             sim_class_def += "domain=domain,"
-        if self.equil is not None and not self.equil.is_default:
+        # This is a bit of a special case since the default is None,
+        if self.equil is not None:
             sim_setup += f"equil = equils.{self.equil.__repr_no_defaults__()}\n"
             sim_class_def += "equil=equil,"
         if not self.grid.is_default:

--- a/src/struphy/topology/grids.py
+++ b/src/struphy/topology/grids.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from struphy.utils.utils import __dataclass_repr_no_defaults__
+
 
 @dataclass
 class TensorProductGrid:
@@ -20,10 +22,13 @@ class TensorProductGrid:
     Nel: tuple = (24, 10, 1)
     mpi_dims_mask: tuple = (True, True, True)
 
-    def __repr__(self):
+    def __str__(self):
         for k, v in self.__dict__.items():
             print(f"{k}:".ljust(20), v)
         return ""
+
+    def __repr_no_defaults__(self):
+        return __dataclass_repr_no_defaults__(self)
 
     def to_dict(self) -> dict:
         dct = {

--- a/src/struphy/topology/grids.py
+++ b/src/struphy/topology/grids.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from struphy.utils.utils import __dataclass_repr_no_defaults__
+from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params_are_default
 
 
 @dataclass
@@ -29,6 +29,10 @@ class TensorProductGrid:
 
     def __repr_no_defaults__(self):
         return __dataclass_repr_no_defaults__(self)
+
+    @property
+    def is_default(self):
+        return all_class_params_are_default(self)
 
     def to_dict(self) -> dict:
         dct = {

--- a/src/struphy/utils/utils.py
+++ b/src/struphy/utils/utils.py
@@ -162,7 +162,7 @@ def all_class_params_are_default(cls_instance):
 
 
 def ruff_autofix_and_format(code: str) -> str:
-    with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w+") as tmp:
         tmp.write(code)
         tmp.flush()
         # Run Ruff to autofix (remove unused imports)

--- a/src/struphy/utils/utils.py
+++ b/src/struphy/utils/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import subprocess
+import tempfile
 from typing import Literal, get_args
 
 import yaml
@@ -158,6 +159,29 @@ def __class_with_params_repr_no_defaults__(cls_instance):
 
 def all_class_params_are_default(cls_instance):
     return cls_instance.__repr_no_defaults__() == cls_instance.__class__.__name__ + "()"
+
+
+def ruff_autofix_and_format(code: str) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w+", delete=False) as tmp:
+        tmp.write(code)
+        tmp.flush()
+        # Run Ruff to autofix (remove unused imports)
+        subprocess.run(
+            ["ruff", "check", "--select", "F401", "--fix", tmp.name],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Run Ruff formatter
+        subprocess.run(
+            ["ruff", "format", tmp.name],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        tmp.seek(0)
+        result = tmp.read()
+    return result
 
 
 if __name__ == "__main__":

--- a/src/struphy/utils/utils.py
+++ b/src/struphy/utils/utils.py
@@ -156,6 +156,10 @@ def __class_with_params_repr_no_defaults__(cls_instance):
     return out
 
 
+def all_class_params_are_default(cls_instance):
+    return cls_instance.__repr_no_defaults__() == cls_instance.__class__.__name__ + "()"
+
+
 if __name__ == "__main__":
     state = read_state()
     for k, val in state.items():

--- a/src/struphy/utils/utils.py
+++ b/src/struphy/utils/utils.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import subprocess
 from typing import Literal, get_args
@@ -130,6 +131,29 @@ def subp_run(cmd, cwd="libpath", check=True):
 
     print(f"\nRunning the following command as a subprocess:\n{' '.join(cmd)}\nfrom {cwd}")
     subprocess.run(cmd, cwd=cwd, check=check)
+
+
+def __dataclass_repr_no_defaults__(obj):
+    out = f"{type(obj).__name__}("
+    for k, v in obj.__dict__.items():
+        if k not in obj.__dataclass_fields__:
+            continue
+        default_value = obj.__dataclass_fields__[k].default
+        if v != default_value:
+            out += f"{k}={repr(v)}, "
+    out = out.rstrip(", ") + ")"
+    return out
+
+
+def __class_with_params_repr_no_defaults__(cls_instance):
+    sig = inspect.signature(cls_instance.__class__.__init__)
+    defaults = {k: v.default for k, v in sig.parameters.items() if k != "self"}
+    out = f"{cls_instance.__class__.__name__}("
+    for k, v in cls_instance.params.items():
+        if k in defaults and v != defaults[k]:
+            out += f"{k}={v}, "
+    out += ")"
+    return out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is based on the idea that `__repr__` should [return a printable representation of an object](https://www.geeksforgeeks.org/python/python-__repr__-magic-method/). The goal is for all objects in the API to have this method, so that a simulation setup can be reproduced using a new `generate_script()` or `save_script(filepath)` method.

- Added `__repr__` and `__repr_no_defaults__` methods to most classes in the API. This allows us to create a repr of the instance without cluttering it with default parameters.
- Renamed a few old `__repr__` methods that would fit better as `__str__`
- Updated tutorials by using `print(x)` instead of `x`
- Added `generate_script()` and `save_script(filepath)` methods to the Simulation class
- The generated strings are formatted with ruff, which also removes unused imports. Therefore, ruff is moved from a dev dependency to a normal dependency. This is the easiest way to use a consistent formatting for the generated scripts.
- Added test to compare the script generation from two simulations.