### PR TITLE
Add iterators to models

### DIFF
--- a/src/struphy/geometry/base.py
+++ b/src/struphy/geometry/base.py
@@ -15,13 +15,7 @@ import struphy.bsplines.bsplines as bsp
 from struphy.geometry import evaluation_kernels, transform_kernels
 from struphy.kernel_arguments.pusher_args_kernels import DomainArguments
 from struphy.linear_algebra import linalg_kron
-from struphy.utils.utils import __class_with_params_repr_no_defaults__, all_class_params_are_default
-
-
-def all_subclasses(cls):
-    subclasses = cls.__subclasses__()
-    subclasses = subclasses + [g for s in subclasses for g in all_subclasses(s)]
-    return subclasses
+from struphy.utils.utils import __class_with_params_repr_no_defaults__, all_class_params_are_default, all_subclasses
 
 
 class DomainMeta(ABCMeta):

--- a/src/struphy/models/base.py
+++ b/src/struphy/models/base.py
@@ -16,10 +16,15 @@ from struphy.pic.base import Particles
 from struphy.propagators.base import Propagator
 from struphy.utils.clone_config import CloneConfig
 from struphy.utils.docstring_converter import rst_to_markdown
-from struphy.utils.utils import all_class_params_are_default
+from struphy.utils.utils import all_class_params_are_default, all_subclasses
 
 
-class StruphyModel(metaclass=ABCMeta):
+class StruphyModelMeta(ABCMeta):
+    def __iter__(cls):
+        return iter(all_subclasses(cls))
+
+
+class StruphyModel(metaclass=StruphyModelMeta):
     """
     Abstract base class for all Struphy models.
 

--- a/src/struphy/models/utils.py
+++ b/src/struphy/models/utils.py
@@ -20,11 +20,9 @@ def get_model_by_name(model_name: str) -> type[StruphyModel]:
 def get_models(model_type: LiteralOptions.ModelTypes | None = None) -> list[type[StruphyModel]]:
     model_classes = []
 
-    for name, obj in inspect.getmembers(models):
-        # Only include classes that are subclasses of StruphyModel, excluding StruphyModel itself
-        if inspect.isclass(obj) and issubclass(obj, StruphyModel) and obj is not StruphyModel:
-            if model_type is None or model_type == obj.model_type():
-                model_classes.append(obj)
+    for model in StruphyModel:
+        if model_type is None or model_type == model.model_type():
+            model_classes.append(model)
 
     return model_classes
 

--- a/src/struphy/utils/utils.py
+++ b/src/struphy/utils/utils.py
@@ -184,6 +184,12 @@ def ruff_autofix_and_format(code: str) -> str:
     return result
 
 
+def all_subclasses(cls):
+    subclasses = cls.__subclasses__()
+    subclasses = subclasses + [g for s in subclasses for g in all_subclasses(s)]
+    return subclasses
+
+
 if __name__ == "__main__":
     state = read_state()
     for k, val in state.items():


### PR DESCRIPTION
This makes looping over the models easier, it can now be done with:

```python
from struphy.models.base import StruphyModel
for model in StruphyModel:
    print(model.__name__)
```

Output

```
ColdPlasma
ColdPlasmaVlasov
DeterministicParticleDiffusion
DriftKineticElectrostaticAdiabatic
GuidingCenter
HasegawaWakatani
LinearExtendedMHDuniform
LinearMHD
LinearMHDDriftkineticCC
LinearMHDVlasovCC
LinearMHDVlasovPC
LinearVlasovAmpereOneSpecies
Maxwell
Poisson
PressureLessSPH
RandomParticleDiffusion
ShearAlfven
TwoFluidQuasiNeutralToy
VariationalBarotropicFluid
VariationalCompressibleFluid
VariationalPressurelessFluid
ViscoResistiveDeltafMHD
ViscoResistiveDeltafMHD_with_q
ViscoResistiveLinearMHD
ViscoResistiveLinearMHD_with_q
ViscoResistiveMHD
ViscoResistiveMHD_with_p
ViscoResistiveMHD_with_q
ViscousEulerSPH
ViscousFluid
Vlasov
VlasovAmpereOneSpecies
VlasovMaxwellOneSpecies
LinearVlasovMaxwellOneSpecies
```