### PR TITLE
Added export and from_file methods to SimulationBase class

### DIFF
--- a/src/struphy/models/tests/utils_testing.py
+++ b/src/struphy/models/tests/utils_testing.py
@@ -90,6 +90,20 @@ def call_test(model: StruphyModel, test_profiling: bool = False, verbose: bool =
 
         # Run the simulation from the generated script
 
+    # Export to json and import again
+    with tempfile.NamedTemporaryFile(suffix=".json", mode="w+") as tmp:
+        sim.save_json(tmp.name)
+        tmp.seek(0)
+        sim_from_json = Simulation.from_json(tmp.name)
+        assert sim == sim_from_json, "Simulation JSON export/import is not consistent"
+
+    # Export to yaml and import again
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w+") as tmp:
+        sim.save_yaml(tmp.name)
+        tmp.seek(0)
+        sim_from_yaml = Simulation.from_yaml(tmp.name)
+        assert sim == sim_from_yaml, "Simulation YAML export/import is not consistent"
+
     sim.show_parameters()
 
     sim.run(verbose=verbose)

--- a/src/struphy/models/tests/utils_testing.py
+++ b/src/struphy/models/tests/utils_testing.py
@@ -92,14 +92,14 @@ def call_test(model: StruphyModel, test_profiling: bool = False, verbose: bool =
 
     # Export to json and import again
     with tempfile.NamedTemporaryFile(suffix=".json", mode="w+") as tmp:
-        sim.save_json(tmp.name)
+        sim.export(tmp.name)
         tmp.seek(0)
         sim_from_json = Simulation.from_file(tmp.name)
         assert sim == sim_from_json, "Simulation JSON export/import is not consistent"
 
     # Export to yaml and import again
     with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w+") as tmp:
-        sim.save_yaml(tmp.name)
+        sim.export(tmp.name)
         tmp.seek(0)
         sim_from_yaml = Simulation.from_file(tmp.name)
         assert sim == sim_from_yaml, "Simulation YAML export/import is not consistent"

--- a/src/struphy/models/tests/utils_testing.py
+++ b/src/struphy/models/tests/utils_testing.py
@@ -94,14 +94,14 @@ def call_test(model: StruphyModel, test_profiling: bool = False, verbose: bool =
     with tempfile.NamedTemporaryFile(suffix=".json", mode="w+") as tmp:
         sim.save_json(tmp.name)
         tmp.seek(0)
-        sim_from_json = Simulation.from_json(tmp.name)
+        sim_from_json = Simulation.from_file(tmp.name)
         assert sim == sim_from_json, "Simulation JSON export/import is not consistent"
 
     # Export to yaml and import again
     with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w+") as tmp:
         sim.save_yaml(tmp.name)
         tmp.seek(0)
-        sim_from_yaml = Simulation.from_yaml(tmp.name)
+        sim_from_yaml = Simulation.from_file(tmp.name)
         assert sim == sim_from_yaml, "Simulation YAML export/import is not consistent"
 
     sim.show_parameters()

--- a/src/struphy/simulation/base.py
+++ b/src/struphy/simulation/base.py
@@ -43,6 +43,16 @@ class SimulationBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def to_dict(self) -> dict:
+        """Serialize the simulation configuration to a dictionary."""
+        pass
+
+    @abstractmethod
+    def from_dict(cls, dct: dict):
+        """Deserialize a simulation configuration from a dictionary."""
+        pass
+
+    @abstractmethod
     def from_file(cls, file_path: str):
         """Deserialize a simulation configuration from a file."""
         pass

--- a/src/struphy/simulation/base.py
+++ b/src/struphy/simulation/base.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABCMeta, abstractmethod
-
+from struphy.utils.utils import dict_to_yaml
 import yaml
 
 

--- a/src/struphy/simulation/base.py
+++ b/src/struphy/simulation/base.py
@@ -1,8 +1,6 @@
 import json
 from abc import ABCMeta, abstractmethod
 
-import yaml
-
 from struphy.utils.utils import dict_to_yaml
 
 
@@ -44,6 +42,11 @@ class SimulationBase(metaclass=ABCMeta):
         """Load post-processed data for visualization."""
         pass
 
+    @abstractmethod
+    def from_file(cls, file_path: str):
+        """Deserialize a simulation configuration from a file."""
+        pass
+
     def export(self, file_path: str):
         """Export a simulation configuration to a YAML or JSON file based on the file extension."""
         dct = self.to_dict()
@@ -54,32 +57,3 @@ class SimulationBase(metaclass=ABCMeta):
                 json.dump(dct, f, indent=4)
         else:
             raise ValueError("Unsupported file format. Use .yaml, .yml or .json.")
-
-    @classmethod
-    def from_file(cls, file_path: str) -> "Simulation":
-        """Deserialize a simulation configuration from a file based on the file extension."""
-        if file_path.endswith(".yaml") or file_path.endswith(".yml"):
-            with open(file_path, "r") as f:
-                dct = yaml.safe_load(f)
-        elif file_path.endswith(".json"):
-            with open(file_path, "r") as f:
-                dct = json.load(f)
-        else:
-            raise ValueError("Unsupported file format. Use .yaml, .yml or .json.")
-
-        # YAML and JSON do not have a native tuple type,
-        # so when you load them with PyYAML or json,
-        # sequences are always converted to lists
-        def convert_lists_to_tuples(obj):
-            if isinstance(obj, dict):
-                for k, v in obj.items():
-                    obj[k] = convert_lists_to_tuples(v)
-                return obj
-            elif isinstance(obj, list):
-                return tuple(convert_lists_to_tuples(i) for i in obj)
-            else:
-                return obj
-
-        # Convert lists to tuples for relevant keys
-        dct = convert_lists_to_tuples(dct)
-        return cls.from_dict(dct)

--- a/src/struphy/simulation/base.py
+++ b/src/struphy/simulation/base.py
@@ -1,4 +1,7 @@
+import json
 from abc import ABCMeta, abstractmethod
+
+import yaml
 
 
 class SimulationBase(metaclass=ABCMeta):
@@ -38,3 +41,27 @@ class SimulationBase(metaclass=ABCMeta):
     def load_plotting_data(self, verbose: bool = False):
         """Load post-processed data for visualization."""
         pass
+
+    def export(self, file_path: str):
+        """Export a simulation configuration to a YAML or JSON file based on the file extension."""
+        dct = self.to_dict()
+        if file_path.endswith(".yaml") or file_path.endswith(".yml"):
+            dict_to_yaml(dct, file_path)
+        elif file_path.endswith(".json"):
+            with open(file_path, "w") as f:
+                json.dump(dct, f, indent=4)
+        else:
+            raise ValueError("Unsupported file format. Use .yaml, .yml or .json.")
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Simulation":
+        """Deserialize a simulation configuration from a file based on the file extension."""
+        if file_path.endswith(".yaml") or file_path.endswith(".yml"):
+            with open(file_path, "r") as f:
+                dct = yaml.safe_load(f)
+        elif file_path.endswith(".json"):
+            with open(file_path, "r") as f:
+                dct = json.load(f)
+        else:
+            raise ValueError("Unsupported file format. Use .yaml, .yml or .json.")
+        return cls.from_dict(dct)

--- a/src/struphy/simulation/base.py
+++ b/src/struphy/simulation/base.py
@@ -1,7 +1,9 @@
 import json
 from abc import ABCMeta, abstractmethod
-from struphy.utils.utils import dict_to_yaml
+
 import yaml
+
+from struphy.utils.utils import dict_to_yaml
 
 
 class SimulationBase(metaclass=ABCMeta):
@@ -64,4 +66,20 @@ class SimulationBase(metaclass=ABCMeta):
                 dct = json.load(f)
         else:
             raise ValueError("Unsupported file format. Use .yaml, .yml or .json.")
+
+        # YAML and JSON do not have a native tuple type,
+        # so when you load them with PyYAML or json,
+        # sequences are always converted to lists
+        def convert_lists_to_tuples(obj):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    obj[k] = convert_lists_to_tuples(v)
+                return obj
+            elif isinstance(obj, list):
+                return tuple(convert_lists_to_tuples(i) for i in obj)
+            else:
+                return obj
+
+        # Convert lists to tuples for relevant keys
+        dct = convert_lists_to_tuples(dct)
         return cls.from_dict(dct)

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1,5 +1,6 @@
 # third party imports
 import glob
+import json
 import os
 import pickle
 import shutil
@@ -9,6 +10,7 @@ import time
 import cunumpy as xp
 import h5py
 import pyvista as pv
+import yaml
 from feectools.ddm.mpi import MockMPI
 from feectools.ddm.mpi import mpi as MPI
 from feectools.linalg.stencil import StencilVector
@@ -1409,6 +1411,35 @@ RESTARTing from:
             derham_opts=DerhamOptions.from_dict(dct["derham_opts"]),
             verbose=dct.get("verbose", False),
         )
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "SimulationBase":
+        """Deserialize a simulation configuration from a file based on the file extension."""
+        if file_path.endswith(".yaml") or file_path.endswith(".yml"):
+            with open(file_path, "r") as f:
+                dct = yaml.safe_load(f)
+        elif file_path.endswith(".json"):
+            with open(file_path, "r") as f:
+                dct = json.load(f)
+        else:
+            raise ValueError("Unsupported file format. Use .yaml, .yml or .json.")
+
+        # YAML and JSON do not have a native tuple type,
+        # so when you load them with PyYAML or json,
+        # sequences are always converted to lists
+        def convert_lists_to_tuples(obj):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    obj[k] = convert_lists_to_tuples(v)
+                return obj
+            elif isinstance(obj, list):
+                return tuple(convert_lists_to_tuples(i) for i in obj)
+            else:
+                return obj
+
+        # Convert lists to tuples for relevant keys
+        dct = convert_lists_to_tuples(dct)
+        return cls.from_dict(dct)
 
     def generate_script(self, include_main_guard: bool = False) -> str:
         """Generate a Python script that can be used to reproduce the simulation."""


### PR DESCRIPTION
Added `export` and `from_file` methods to the `SimulationBase` class. Now all the following examples work:

```python
from struphy import Simulation
from struphy.models import Maxwell

sim1 = Simulation(model=Maxwell())

# Test 1 - to_dict/from_dict
dct = sim1.to_dict()
sim2 = Simulation.from_dict(dct)
assert sim1 == sim2

# Test 2 - export/import YAML
sim1.export("sim1.yaml")
sim3 = Simulation.from_file("sim1.yaml")
assert sim1 == sim3

# Test 3 - export/import JSON
sim1.export("sim1.json")
sim4 = Simulation.from_file("sim1.json")
assert sim1 == sim4
```