### PR TITLE
Unify dict generation

### DIFF
--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -10,8 +10,9 @@ class OptionsBase:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
-    def from_dict(cls, dct) -> "OptionsBase":
-        return cls(**dct)
+    def from_dict(cls, dct) -> "Any":
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 
 
 @dataclass
@@ -107,17 +108,9 @@ class LiteralOptions:
         "heat_flux_3",
     ]
 
-    def to_dict(self) -> dict:
-        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
-
-    @classmethod
-    def from_dict(cls, dct) -> "LiteralOptions":
-        valid_fields = {field.name for field in fields(cls) if field.init}
-        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
-
 
 @dataclass
-class Time:
+class Time(OptionsBase):
     """Set options for time stepping in parameter/launch files.
 
     Parameters
@@ -151,17 +144,9 @@ class Time:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    def to_dict(self) -> dict:
-        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
-
-    @classmethod
-    def from_dict(cls, dct) -> "Time":
-        valid_fields = {field.name for field in fields(cls) if field.init}
-        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
-
 
 @dataclass
-class BaseUnits:
+class BaseUnits(OptionsBase):
     """Set base units in parameter/launch files from which other units are derived. See :ref:`normalization`.
 
     Parameters
@@ -198,17 +183,9 @@ class BaseUnits:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    def to_dict(self) -> dict:
-        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
-
-    @classmethod
-    def from_dict(cls, dct) -> "BaseUnits":
-        valid_fields = {field.name for field in fields(cls) if field.init}
-        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
-
 
 @dataclass
-class DerhamOptions:
+class DerhamOptions(OptionsBase):
     """Set options for the Derham spaces in parameter/launch files. See :ref:`geomFE`.
 
     Parameters
@@ -258,17 +235,9 @@ class DerhamOptions:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    def to_dict(self) -> dict:
-        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
-
-    @classmethod
-    def from_dict(cls, dct) -> "DerhamOptions":
-        valid_fields = {field.name for field in fields(cls) if field.init}
-        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
-
 
 @dataclass
-class FieldsBackground:
+class FieldsBackground(OptionsBase):
     """Set options for static fluid backgrounds/equilibria in parameter/launch files.
 
     Parameters
@@ -303,17 +272,9 @@ class FieldsBackground:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    def to_dict(self) -> dict:
-        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
-
-    @classmethod
-    def from_dict(cls, dct) -> "FieldsBackground":
-        valid_fields = {field.name for field in fields(cls) if field.init}
-        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
-
 
 @dataclass
-class EnvironmentOptions:
+class EnvironmentOptions(OptionsBase):
     """Set environment options for launching run on current architecture
     (these options do not influence the simulation result).
 
@@ -372,11 +333,3 @@ class EnvironmentOptions:
     @property
     def is_default(self):
         return all_class_params_are_default(self)
-
-    def to_dict(self) -> dict:
-        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
-
-    @classmethod
-    def from_dict(cls, dct) -> "EnvironmentOptions":
-        valid_fields = {field.name for field in fields(cls) if field.init}
-        return cls(**{key: value for key, value in dct.items() if key in valid_fields})

--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -1,9 +1,9 @@
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any, Literal
-from dataclasses import fields
 
 from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params_are_default, check_option
+
 
 class OptionsBase:
     def to_dict(self) -> dict:
@@ -12,6 +12,7 @@ class OptionsBase:
     @classmethod
     def from_dict(cls, dct) -> "OptionsBase":
         return cls(**dct)
+
 
 @dataclass
 class LiteralOptions:
@@ -106,13 +107,6 @@ class LiteralOptions:
         "heat_flux_3",
     ]
 
-    # def to_dict(self) -> dict:
-    #     dct = {k: v for k, v in self.__dict__.items()}
-    #     return dct
-
-    # @classmethod
-    # def from_dict(cls, dct) -> "LiteralOptions":
-    #     return cls(**dct)
     def to_dict(self) -> dict:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
@@ -157,21 +151,6 @@ class Time:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    # def to_dict(self) -> dict:
-    #     dct = {
-    #         "dt": self.dt,
-    #         "Tend": self.Tend,
-    #         "split_algo": self.split_algo,
-    #     }
-    #     return dct
-
-    # @classmethod
-    # def from_dict(cls, dct) -> "Time":
-    #     return cls(
-    #         dt=dct["dt"],
-    #         Tend=dct["Tend"],
-    #         split_algo=dct["split_algo"],
-    #     )
     def to_dict(self) -> dict:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
@@ -219,23 +198,6 @@ class BaseUnits:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    # def to_dict(self) -> dict:
-    #     dct = {
-    #         "x": self.x,
-    #         "B": self.B,
-    #         "n": self.n,
-    #         "kBT": self.kBT,
-    #     }
-    #     return dct
-
-    # @classmethod
-    # def from_dict(cls, dct) -> "BaseUnits":
-    #     return cls(
-    #         x=dct["x"],
-    #         B=dct["B"],
-    #         n=dct["n"],
-    #         kBT=dct.get("kBT", None),
-    #     )
     def to_dict(self) -> dict:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
@@ -296,29 +258,6 @@ class DerhamOptions:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    # def to_dict(self) -> dict:
-    #     dct = {
-    #         "p": self.p,
-    #         "spl_kind": self.spl_kind,
-    #         "dirichlet_bc": self.dirichlet_bc,
-    #         "nquads": self.nquads,
-    #         "nq_pr": self.nq_pr,
-    #         "polar_ck": self.polar_ck,
-    #         "local_projectors": self.local_projectors,
-    #     }
-    #     return dct
-
-    # @classmethod
-    # def from_dict(cls, dct) -> "DerhamOptions":
-    #     return cls(
-    #         p=dct["p"],
-    #         spl_kind=dct["spl_kind"],
-    #         dirichlet_bc=dct["dirichlet_bc"],
-    #         nquads=dct["nquads"],
-    #         nq_pr=dct["nq_pr"],
-    #         polar_ck=dct["polar_ck"],
-    #         local_projectors=dct["local_projectors"],
-    #     )
     def to_dict(self) -> dict:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
@@ -364,21 +303,6 @@ class FieldsBackground:
     def is_default(self):
         return all_class_params_are_default(self)
 
-    # def to_dict(self) -> dict:
-    #     dct = {
-    #         "type": self.type,
-    #         "values": self.values,
-    #         "variable": self.variable,
-    #     }
-    #     return dct
-
-    # @classmethod
-    # def from_dict(cls, dct) -> "FieldsBackground":
-    #     return cls(
-    #         type=dct["type"],
-    #         values=dct["values"],
-    #         variable=dct["variable"],
-    #     )
     def to_dict(self) -> dict:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
@@ -448,20 +372,6 @@ class EnvironmentOptions:
     @property
     def is_default(self):
         return all_class_params_are_default(self)
-
-    # def to_dict(self) -> dict:
-    #     dct = {
-    #         "out_folders": self.out_folders,
-    #         "sim_folder": self.sim_folder,
-    #         "restart": self.restart,
-    #         "max_runtime": self.max_runtime,
-    #         "save_step": self.save_step,
-    #         "sort_step": self.sort_step,
-    #         "num_clones": self.num_clones,
-    #         "profiling_activated": self.profiling_activated,
-    #         "profiling_trace": self.profiling_trace,
-    #     }
-    #     return dct
 
     def to_dict(self) -> dict:
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}

--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -7,12 +7,12 @@ from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params
 
 class OptionsBase:
     def to_dict(self) -> dict:
-        """Convert dataclass instance to dictionary, including only fields that are initialized (i.e., not default values)."""
+        """Convert dataclass instance to dictionary."""
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "Any":
-        """Create dataclass instance from dictionary, including only fields that are initialized (i.e., not default values)."""
+        """Create dataclass instance from dictionary."""
         valid_fields = {field.name for field in fields(cls) if field.init}
         return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 

--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -1,9 +1,17 @@
 import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
+from dataclasses import fields
 
 from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params_are_default, check_option
 
+class OptionsBase:
+    def to_dict(self) -> dict:
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
+
+    @classmethod
+    def from_dict(cls, dct) -> "OptionsBase":
+        return cls(**dct)
 
 @dataclass
 class LiteralOptions:
@@ -98,13 +106,20 @@ class LiteralOptions:
         "heat_flux_3",
     ]
 
+    # def to_dict(self) -> dict:
+    #     dct = {k: v for k, v in self.__dict__.items()}
+    #     return dct
+
+    # @classmethod
+    # def from_dict(cls, dct) -> "LiteralOptions":
+    #     return cls(**dct)
     def to_dict(self) -> dict:
-        dct = {k: v for k, v in self.__dict__.items()}
-        return dct
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "LiteralOptions":
-        return cls(**dct)
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 
 
 @dataclass
@@ -142,21 +157,28 @@ class Time:
     def is_default(self):
         return all_class_params_are_default(self)
 
+    # def to_dict(self) -> dict:
+    #     dct = {
+    #         "dt": self.dt,
+    #         "Tend": self.Tend,
+    #         "split_algo": self.split_algo,
+    #     }
+    #     return dct
+
+    # @classmethod
+    # def from_dict(cls, dct) -> "Time":
+    #     return cls(
+    #         dt=dct["dt"],
+    #         Tend=dct["Tend"],
+    #         split_algo=dct["split_algo"],
+    #     )
     def to_dict(self) -> dict:
-        dct = {
-            "dt": self.dt,
-            "Tend": self.Tend,
-            "split_algo": self.split_algo,
-        }
-        return dct
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "Time":
-        return cls(
-            dt=dct["dt"],
-            Tend=dct["Tend"],
-            split_algo=dct["split_algo"],
-        )
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 
 
 @dataclass
@@ -197,23 +219,30 @@ class BaseUnits:
     def is_default(self):
         return all_class_params_are_default(self)
 
+    # def to_dict(self) -> dict:
+    #     dct = {
+    #         "x": self.x,
+    #         "B": self.B,
+    #         "n": self.n,
+    #         "kBT": self.kBT,
+    #     }
+    #     return dct
+
+    # @classmethod
+    # def from_dict(cls, dct) -> "BaseUnits":
+    #     return cls(
+    #         x=dct["x"],
+    #         B=dct["B"],
+    #         n=dct["n"],
+    #         kBT=dct.get("kBT", None),
+    #     )
     def to_dict(self) -> dict:
-        dct = {
-            "x": self.x,
-            "B": self.B,
-            "n": self.n,
-            "kBT": self.kBT,
-        }
-        return dct
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "BaseUnits":
-        return cls(
-            x=dct["x"],
-            B=dct["B"],
-            n=dct["n"],
-            kBT=dct.get("kBT", None),
-        )
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 
 
 @dataclass
@@ -267,29 +296,36 @@ class DerhamOptions:
     def is_default(self):
         return all_class_params_are_default(self)
 
+    # def to_dict(self) -> dict:
+    #     dct = {
+    #         "p": self.p,
+    #         "spl_kind": self.spl_kind,
+    #         "dirichlet_bc": self.dirichlet_bc,
+    #         "nquads": self.nquads,
+    #         "nq_pr": self.nq_pr,
+    #         "polar_ck": self.polar_ck,
+    #         "local_projectors": self.local_projectors,
+    #     }
+    #     return dct
+
+    # @classmethod
+    # def from_dict(cls, dct) -> "DerhamOptions":
+    #     return cls(
+    #         p=dct["p"],
+    #         spl_kind=dct["spl_kind"],
+    #         dirichlet_bc=dct["dirichlet_bc"],
+    #         nquads=dct["nquads"],
+    #         nq_pr=dct["nq_pr"],
+    #         polar_ck=dct["polar_ck"],
+    #         local_projectors=dct["local_projectors"],
+    #     )
     def to_dict(self) -> dict:
-        dct = {
-            "p": self.p,
-            "spl_kind": self.spl_kind,
-            "dirichlet_bc": self.dirichlet_bc,
-            "nquads": self.nquads,
-            "nq_pr": self.nq_pr,
-            "polar_ck": self.polar_ck,
-            "local_projectors": self.local_projectors,
-        }
-        return dct
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "DerhamOptions":
-        return cls(
-            p=dct["p"],
-            spl_kind=dct["spl_kind"],
-            dirichlet_bc=dct["dirichlet_bc"],
-            nquads=dct["nquads"],
-            nq_pr=dct["nq_pr"],
-            polar_ck=dct["polar_ck"],
-            local_projectors=dct["local_projectors"],
-        )
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 
 
 @dataclass
@@ -328,21 +364,28 @@ class FieldsBackground:
     def is_default(self):
         return all_class_params_are_default(self)
 
+    # def to_dict(self) -> dict:
+    #     dct = {
+    #         "type": self.type,
+    #         "values": self.values,
+    #         "variable": self.variable,
+    #     }
+    #     return dct
+
+    # @classmethod
+    # def from_dict(cls, dct) -> "FieldsBackground":
+    #     return cls(
+    #         type=dct["type"],
+    #         values=dct["values"],
+    #         variable=dct["variable"],
+    #     )
     def to_dict(self) -> dict:
-        dct = {
-            "type": self.type,
-            "values": self.values,
-            "variable": self.variable,
-        }
-        return dct
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "FieldsBackground":
-        return cls(
-            type=dct["type"],
-            values=dct["values"],
-            variable=dct["variable"],
-        )
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 
 
 @dataclass
@@ -406,30 +449,24 @@ class EnvironmentOptions:
     def is_default(self):
         return all_class_params_are_default(self)
 
+    # def to_dict(self) -> dict:
+    #     dct = {
+    #         "out_folders": self.out_folders,
+    #         "sim_folder": self.sim_folder,
+    #         "restart": self.restart,
+    #         "max_runtime": self.max_runtime,
+    #         "save_step": self.save_step,
+    #         "sort_step": self.sort_step,
+    #         "num_clones": self.num_clones,
+    #         "profiling_activated": self.profiling_activated,
+    #         "profiling_trace": self.profiling_trace,
+    #     }
+    #     return dct
+
     def to_dict(self) -> dict:
-        dct = {
-            "out_folders": self.out_folders,
-            "sim_folder": self.sim_folder,
-            "restart": self.restart,
-            "max_runtime": self.max_runtime,
-            "save_step": self.save_step,
-            "sort_step": self.sort_step,
-            "num_clones": self.num_clones,
-            "profiling_activated": self.profiling_activated,
-            "profiling_trace": self.profiling_trace,
-        }
-        return dct
+        return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "EnvironmentOptions":
-        return cls(
-            out_folders=dct["out_folders"],
-            sim_folder=dct["sim_folder"],
-            restart=dct["restart"],
-            max_runtime=dct["max_runtime"],
-            save_step=dct["save_step"],
-            sort_step=dct["sort_step"],
-            num_clones=dct["num_clones"],
-            profiling_activated=dct["profiling_activated"],
-            profiling_trace=dct["profiling_trace"],
-        )
+        valid_fields = {field.name for field in fields(cls) if field.init}
+        return cls(**{key: value for key, value in dct.items() if key in valid_fields})

--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -7,10 +7,12 @@ from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params
 
 class OptionsBase:
     def to_dict(self) -> dict:
+        """Convert dataclass instance to dictionary, including only fields that are initialized (i.e., not default values)."""
         return {field.name: getattr(self, field.name) for field in fields(type(self)) if field.init}
 
     @classmethod
     def from_dict(cls, dct) -> "Any":
+        """Create dataclass instance from dictionary, including only fields that are initialized (i.e., not default values)."""
         valid_fields = {field.name for field in fields(cls) if field.init}
         return cls(**{key: value for key, value in dct.items() if key in valid_fields})
 

--- a/src/struphy/topology/grids.py
+++ b/src/struphy/topology/grids.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-
+from typing import Tuple
 import numpy as np
 
 from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params_are_default
@@ -11,16 +11,16 @@ class TensorProductGrid:
 
     Parameters
     ----------
-    Nel : tuple[int]
+    Nel : Tuple[int, int, int]
         Number of elements in each direction.
 
-    mpi_dims_mask: Tuple of bool
+    mpi_dims_mask: Tuple[bool, bool, bool]
         True if the dimension is to be used in the domain decomposition (=default for each dimension).
         If mpi_dims_mask[i]=False, the i-th dimension will not be decomposed.
     """
 
-    Nel: tuple = (24, 10, 1)
-    mpi_dims_mask: tuple = (True, True, True)
+    Nel: Tuple[int, int, int] = (24, 10, 1)
+    mpi_dims_mask: Tuple[bool, bool, bool] = (True, True, True)
 
     def __str__(self):
         for k, v in self.__dict__.items():
@@ -44,6 +44,6 @@ class TensorProductGrid:
     @classmethod
     def from_dict(cls, dct) -> "TensorProductGrid":
         return cls(
-            Nel=dct["Nel"],
-            mpi_dims_mask=dct["mpi_dims_mask"],
+            Nel=tuple(dct["Nel"]),
+            mpi_dims_mask=tuple(dct["mpi_dims_mask"]),
         )

--- a/src/struphy/topology/grids.py
+++ b/src/struphy/topology/grids.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Tuple
+
 import numpy as np
 
 from struphy.utils.utils import __dataclass_repr_no_defaults__, all_class_params_are_default


### PR DESCRIPTION
- This PR cleans up the dict generation for the options classes by introducing an `OptionsBase` class.
- Improved the `TensorProductGrid` class by converting lists from the dicts to tuples. This is needed because by default yaml does not support tuples.
- Added correct typehints for `TensorProductGrid `