### PR TITLE
Resolve 171 init files are not formatted at the moment

### DIFF
--- a/src/struphy/console/format.py
+++ b/src/struphy/console/format.py
@@ -1278,60 +1278,70 @@ def run_linters_on_files(linters, python_files, flags, verbose):
                     print(line, end="")
 
 
-def construct_models_init_file(models_dir: str = "src/struphy/models") -> str:
+def construct_package_init_file(package_dir: str, package_name: str, base_class: type, skip: tuple = ("base.py",)) -> str:
     """
-    Constructs __init__.py for all generated model files by reading actual class names.
-    Skips base.py and __init__.py.
+    Constructs the content of an `__init__.py` file for a package laid out with one class
+    per module, by importing each module and collecting the subclasses of `base_class` that
+    are defined in it. Preserves the existing module docstring of the `__init__.py`, if any.
+
+    Parameters
+    ----------
+    package_dir : str
+        Path to the package directory (e.g. "src/struphy/models").
+
+    package_name : str
+        Dotted import path of the package (e.g. "struphy.models").
+
+    base_class : type
+        Only classes that are (strict) subclasses of `base_class`, and defined directly in
+        the module being scanned, are collected.
+
+    skip : tuple, optional
+        Module filenames to skip in addition to `__init__.py` (default=("base.py",)).
     """
-    existing_init_path = os.path.join(models_dir, "__init__.py")
+    existing_init_path = os.path.join(package_dir, "__init__.py")
     docstring = None
     if os.path.isfile(existing_init_path):
         with open(existing_init_path, "r") as f:
             docstring = ast.get_docstring(ast.parse(f.read()), clean=False)
 
-    models_init = f'"""{docstring}"""\n\n' if docstring else ""
-    model_names = []
+    init_content = f'"""{docstring}"""\n\n' if docstring else ""
+    class_names = []
 
-    for file_name in sorted(os.listdir(models_dir)):
-        if file_name.endswith(".py") and file_name not in ["__init__.py", "base.py"]:
+    for file_name in sorted(os.listdir(package_dir)):
+        if file_name.endswith(".py") and file_name not in ("__init__.py", *skip):
             module_name = file_name[:-3]  # strip .py
-            module = importlib.import_module(f"struphy.models.{module_name}")
+            module = importlib.import_module(f"{package_name}.{module_name}")
 
             # Loop over all classes in the module
             for _, cls in inspect.getmembers(module, inspect.isclass):
-                # Only subclasses of StruphyModel defined in this module
-                if issubclass(cls, StruphyModel) and cls.__module__ == module.__name__ and cls != StruphyModel:
+                # Only subclasses of base_class defined in this module
+                if issubclass(cls, base_class) and cls.__module__ == module.__name__ and cls != base_class:
                     class_name = cls.__name__
-                    models_init += f"from struphy.models.{module_name} import {class_name}\n"
-                    model_names.append(class_name)
+                    init_content += f"from {package_name}.{module_name} import {class_name}\n"
+                    class_names.append(class_name)
 
-    models_init += "\n\n"
-    models_init += f"__all__ = {model_names}\n"
-    return models_init
+    init_content += "\n\n"
+    init_content += f"__all__ = {class_names}\n"
+    return init_content
 
 
-def construct_propagators_init_file() -> str:
+def construct_models_init_file(models_dir: str = "src/struphy/models") -> str:
     """
-    Constructs the content for the __init__.py file for the propagators module.
-
-    Returns:
-        str: The content for the __init__.py file as a string.
+    Constructs __init__.py for all generated model files by reading actual class names.
+    Skips base.py and __init__.py.
     """
-    import struphy.propagators.propagators_coupling as propagators_coupling
-    import struphy.propagators.propagators_fields as propagators_fields
-    import struphy.propagators.propagators_markers as propagators_markers
+    return construct_package_init_file(models_dir, "struphy.models", StruphyModel)
+
+
+def construct_propagators_init_file(propagators_dir: str = "src/struphy/propagators") -> str:
+    """
+    Constructs __init__.py for all generated propagator files by reading actual class names.
+    Skips base.py and __init__.py.
+    """
     from struphy.propagators.base import Propagator
 
-    propagators_init = ""
-    propagators_names = []
-    for model_type in [propagators_coupling, propagators_fields, propagators_markers]:
-        for _, cls in model_type.__dict__.items():
-            if isinstance(cls, type) and issubclass(cls, Propagator) and cls != Propagator:
-                propagators_names.append(cls.__name__)
-                propagators_init += f"from {model_type.__name__} import {cls.__name__}\n"
-    propagators_init += "\n\n"
-    propagators_init += f"__all__ = {propagators_names}\n"
-    return propagators_init
+    return construct_package_init_file(propagators_dir, "struphy.propagators", Propagator)
 
 
 def run_formatting_loop(python_files, linters, iterations, verbose):
@@ -1438,9 +1448,9 @@ def struphy_format(config, verbose, yes=False):
 def struphy_build_init_files(config, verbose, yes=False):
     """Regenerate the auto-generated `__init__.py` files and format them.
 
-    Currently this (re-)writes `struphy/models/__init__.py` based on the
-    `StruphyModel` subclasses found in `struphy/models/`, preserving its
-    existing module docstring, and then formats the result.
+    This (re-)writes `struphy/models/__init__.py` and `struphy/propagators/__init__.py`
+    based on the `StruphyModel`/`Propagator` subclasses found in those packages,
+    preserving each file's existing module docstring, and then formats the result.
 
     Parameters
     ----------
@@ -1466,7 +1476,12 @@ def struphy_build_init_files(config, verbose, yes=False):
     with open(MODELS_INIT_PATH, "w") as f:
         f.write(models_init)
 
-    python_files = [MODELS_INIT_PATH]
+    print(f"Rewriting {PROPAGATORS_INIT_PATH}")
+    propagators_init = construct_propagators_init_file()
+    with open(PROPAGATORS_INIT_PATH, "w") as f:
+        f.write(propagators_init)
+
+    python_files = [MODELS_INIT_PATH, PROPAGATORS_INIT_PATH]
 
     confirm_formatting(python_files, linters, yes)
 

--- a/src/struphy/console/format.py
+++ b/src/struphy/console/format.py
@@ -415,7 +415,10 @@ def parse_path(directory, verbose: bool = False):
         for filename in files:
             if re.search(r"__\w+__", root):
                 continue
-            if (filename.endswith(".py") or filename.endswith(".ipynb")) and not re.search(r"__\w+__", filename):
+            # Dunder files (e.g. '__main__.py') are excluded, but '__init__.py' is kept
+            # so that it still gets linted/formatted.
+            is_dunder_file = re.match(r"^__\w+__\.py$", filename) and filename != "__init__.py"
+            if (filename.endswith(".py") or filename.endswith(".ipynb")) and not is_dunder_file:
                 file_path = os.path.join(root, filename)
                 python_files.append(file_path)
     return python_files
@@ -1280,7 +1283,13 @@ def construct_models_init_file(models_dir: str = "src/struphy/models") -> str:
     Constructs __init__.py for all generated model files by reading actual class names.
     Skips base.py and __init__.py.
     """
-    models_init = ""
+    existing_init_path = os.path.join(models_dir, "__init__.py")
+    docstring = None
+    if os.path.isfile(existing_init_path):
+        with open(existing_init_path, "r") as f:
+            docstring = ast.get_docstring(ast.parse(f.read()), clean=False)
+
+    models_init = f'"""{docstring}"""\n\n' if docstring else ""
     model_names = []
 
     for file_name in sorted(os.listdir(models_dir)):
@@ -1325,6 +1334,64 @@ def construct_propagators_init_file() -> str:
     return propagators_init
 
 
+def run_formatting_loop(python_files, linters, iterations, verbose):
+    """Repeatedly run the given formatters on `python_files` until they are clean.
+
+    Parameters
+    ----------
+    python_files : list
+        List of Python file paths to format.
+
+    linters : list
+        List of formatter names to apply.
+
+    iterations : int
+        Maximum number of times to apply formatting.
+
+    verbose : bool
+        If True, enables detailed output, showing each command and iteration.
+    """
+
+    flags = {
+        "autopep8": ["--in-place"],
+        "isort": [],
+        "add-trailing-comma": ["--exit-zero-even-if-changed"],
+        "ruff": [["check", "--fix", "--select", "I"], ["format"]],
+        "ssort": [],
+    }
+
+    # Skip linting with add-trailing-comma since it disagrees with autopep8
+    skip_linters = ["add-trailing-comma"]
+
+    for iteration in range(iterations):
+        if verbose:
+            print(f"Iteration {iteration + 1}: Running formatters...")
+
+        run_linters_on_files(
+            linters,
+            python_files,
+            flags,
+            verbose,
+        )
+
+        # Check if any files still require changes
+        if not files_require_formatting(
+            python_files,
+            [lint for lint in linters if lint not in skip_linters],
+        ):
+            print("All files are properly formatted.")
+            break
+    else:
+        if verbose:
+            print(
+                "Max iterations reached. The following files may still require manual checks:",
+            )
+            for file_path in python_files:
+                if files_require_formatting([file_path], linters):
+                    print(f" - {file_path}")
+            print("Contact Max about this")
+
+
 def struphy_format(config, verbose, yes=False):
     """Format Python files with specified linters, optionally iterating multiple times.
 
@@ -1333,7 +1400,7 @@ def struphy_format(config, verbose, yes=False):
     config : dict
         Configuration dictionary containing the following keys:
             - input_type : str, optional
-                The type of files to format ('all', 'path', 'staged', 'branch', or '__init__.py'). Defaults to 'all'.
+                The type of files to format ('all', 'path', 'staged', or 'branch'). Defaults to 'all'.
             - path : str, optional
                 Directory or file path where files will be formatted.
             - linters : list
@@ -1357,24 +1424,7 @@ def struphy_format(config, verbose, yes=False):
     if input_type is None and path is not None:
         input_type = "path"
 
-    if input_type == "__init__.py":
-        # print(f"Rewriting {PROPAGATORS_INIT_PATH}")
-        # propagators_init = construct_propagators_init_file()
-        # with open(PROPAGATORS_INIT_PATH, "w") as f:
-        #     f.write(propagators_init)
-
-        print(f"Rewriting {MODELS_INIT_PATH}")
-        models_init = construct_models_init_file()
-        with open(MODELS_INIT_PATH, "w") as f:
-            f.write(models_init)
-
-        python_files = [
-            # PROPAGATORS_INIT_PATH,
-            MODELS_INIT_PATH,
-        ]
-        input_type = "path"
-    else:
-        python_files = get_python_files(input_type, path)
+    python_files = get_python_files(input_type, path)
 
     if len(python_files) == 0:
         print("No Python files to format.")
@@ -1382,44 +1432,42 @@ def struphy_format(config, verbose, yes=False):
 
     confirm_formatting(python_files, linters, yes)
 
-    flags = {
-        "autopep8": ["--in-place"],
-        "isort": [],
-        "add-trailing-comma": ["--exit-zero-even-if-changed"],
-        "ruff": [["check", "--fix", "--select", "I"], ["format"]],
-        "ssort": [],
-    }
+    run_formatting_loop(python_files, linters, iterations, verbose)
 
-    # Skip linting with add-trailing-comma since it disagrees with autopep8
-    skip_linters = ["add-trailing-comma"]
 
-    if python_files:
-        for iteration in range(iterations):
-            if verbose:
-                print(f"Iteration {iteration + 1}: Running formatters...")
+def struphy_build_init_files(config, verbose, yes=False):
+    """Regenerate the auto-generated `__init__.py` files and format them.
 
-            run_linters_on_files(
-                linters,
-                python_files,
-                flags,
-                verbose,
-            )
+    Currently this (re-)writes `struphy/models/__init__.py` based on the
+    `StruphyModel` subclasses found in `struphy/models/`, preserving its
+    existing module docstring, and then formats the result.
 
-            # Check if any files still require changes
-            if not files_require_formatting(
-                python_files,
-                [lint for lint in linters if lint not in skip_linters],
-            ):
-                print("All files are properly formatted.")
-                break
-        else:
-            if verbose:
-                print(
-                    "Max iterations reached. The following files may still require manual checks:",
-                )
-                for file_path in python_files:
-                    if files_require_formatting([file_path], linters):
-                        print(f" - {file_path}")
-                print("Contact Max about this")
-    else:
-        print("No Python files to format.")
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary containing the following keys:
+            - linters : list
+                List of formatter names to apply.
+            - iterations : int, optional
+                Maximum number of times to apply formatting (default=5).
+
+    verbose : bool
+        If True, enables detailed output, showing each command and iteration.
+
+    yes : bool, optional
+        If True, skips the confirmation prompt before formatting.
+    """
+
+    linters = config.get("linters", ["ruff"])
+    iterations = config.get("iterations", 5)
+
+    print(f"Rewriting {MODELS_INIT_PATH}")
+    models_init = construct_models_init_file()
+    with open(MODELS_INIT_PATH, "w") as f:
+        f.write(models_init)
+
+    python_files = [MODELS_INIT_PATH]
+
+    confirm_formatting(python_files, linters, yes)
+
+    run_formatting_loop(python_files, linters, iterations, verbose)

--- a/src/struphy/console/format.py
+++ b/src/struphy/console/format.py
@@ -1278,7 +1278,9 @@ def run_linters_on_files(linters, python_files, flags, verbose):
                     print(line, end="")
 
 
-def construct_package_init_file(package_dir: str, package_name: str, base_class: type, skip: tuple = ("base.py",)) -> str:
+def construct_package_init_file(
+    package_dir: str, package_name: str, base_class: type, skip: tuple = ("base.py",)
+) -> str:
     """
     Constructs the content of an `__init__.py` file for a package laid out with one class
     per module, by importing each module and collecting the subclasses of `base_class` that

--- a/src/struphy/console/main.py
+++ b/src/struphy/console/main.py
@@ -125,6 +125,7 @@ def struphy():
         "compile": ("struphy.console.compile", "struphy_compile"),
         "lint": ("struphy.console.format", "struphy_lint"),
         "format": ("struphy.console.format", "struphy_format"),
+        "build-init-files": ("struphy.console.format", "struphy_build_init_files"),
         "likwid_profile": ("struphy.console.likwid", "struphy_likwid_profile"),
         "params": ("struphy.console.params", "struphy_params"),
         "profile": ("struphy.console.profile", "struphy_profile"),
@@ -522,7 +523,7 @@ def add_parser_format(subparsers):
             subparser.add_argument(
                 "input_type",
                 type=str,
-                choices=["all", "staged", "branch", "__init__.py"],
+                choices=["all", "staged", "branch"],
                 nargs="?",  # optional
                 help="specify the files to process",
             )
@@ -580,6 +581,38 @@ def add_parser_format(subparsers):
             help="specify the format of the output: 'table' for tabular output, 'plain' for regular output, or 'report' for saving a html report",
         )
 
+        parser_build_init_files = subparsers.add_parser(
+            "build-init-files",
+            help="regenerate auto-generated __init__.py files",
+            description="Regenerate the auto-generated __init__.py files (e.g. struphy/models/__init__.py) and format them.",
+        )
+        parser_build_init_files.add_argument(
+            "--verbose",
+            action="store_true",
+            help="use verbose output",
+        )
+        parser_build_init_files.add_argument(
+            "--linters",
+            type=str,
+            nargs="+",
+            default=["ruff"],
+            choices=["add-trailing-comma", "isort", "autopep8", "ruff"],
+            help="list of linters to use",
+        )
+        parser_build_init_files.add_argument(
+            "--iterations",
+            type=int,
+            default=5,
+            help="maximum number of times to run each formatter",
+        )
+        build_init_files_group = parser_build_init_files.add_argument_group("build-init-files options")
+        build_init_files_group.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            help="say yes to prompt when asked if all files should be formatted",
+        )
+
 
 def set_args_format_config(args, parser):
     if args.command == "format" or args.command == "lint":
@@ -595,6 +628,12 @@ def set_args_format_config(args, parser):
         args.config["iterations"] = args.iterations
     if args.command == "lint":
         args.config["output_format"] = args.output_format
+
+    if args.command == "build-init-files":
+        args.config = {
+            "linters": args.linters,
+            "iterations": args.iterations,
+        }
 
 
 def print_short_help(parser):

--- a/src/struphy/propagators/__init__.py
+++ b/src/struphy/propagators/__init__.py
@@ -1,93 +1,91 @@
-# from struphy.propagators.propagators_coupling import (
-#     CurrentCoupling5DCurlb,
-#     CurrentCoupling5DGradB,
-#     CurrentCoupling6DCurrent,
-#     EfieldWeights,
-#     PressureCoupling6D,
-#     VlasovAmpere,
-# )
-# from struphy.propagators.propagators_fields import (
-#     AdiabaticPhi,
-#     CurrentCoupling5DDensity,
-#     CurrentCoupling6DDensity,
-#     FaradayExtended,
-#     Hall,
-#     HasegawaWakatani,
-#     ImplicitDiffusion,
-#     JxBCold,
-#     Magnetosonic,
-#     MagnetosonicUniform,
-#     Maxwell,
-#     OhmCold,
-#     Poisson,
-#     ShearAlfven,
-#     ShearAlfvenB1,
-#     ShearAlfvenCurrentCoupling5D,
-#     TimeDependentSource,
-#     TwoFluidQuasiNeutralFull,
-#     VariationalDensityEvolve,
-#     VariationalEntropyEvolve,
-#     VariationalMagFieldEvolve,
-#     VariationalMomentumAdvection,
-#     VariationalPBEvolve,
-#     VariationalQBEvolve,
-#     VariationalResistivity,
-#     VariationalViscosity,
-# )
-# from struphy.propagators.propagators_markers import (
-#     PushDeterministicDiffusion,
-#     PushEta,
-#     PushEtaPC,
-#     PushGuidingCenterBxEstar,
-#     PushGuidingCenterParallel,
-#     PushRandomDiffusion,
-#     PushVinEfield,
-#     PushVinSPHpressure,
-#     PushVinViscousPotential,
-#     PushVxB,
-# )
+from struphy.propagators.adiabatic_phi import AdiabaticPhi
+from struphy.propagators.curl_curl_solve import CurlCurlSolve
+from struphy.propagators.current_coupling_5d_curlb import CurrentCoupling5DCurlb
+from struphy.propagators.current_coupling_5d_density import CurrentCoupling5DDensity
+from struphy.propagators.current_coupling_5d_gradb import CurrentCoupling5DGradB
+from struphy.propagators.current_coupling_6d_current import CurrentCoupling6DCurrent
+from struphy.propagators.current_coupling_6d_density import CurrentCoupling6DDensity
+from struphy.propagators.efield_weights_coupling import EfieldWeightsCoupling
+from struphy.propagators.faraday_extended import FaradayExtended
+from struphy.propagators.hall import Hall
+from struphy.propagators.hasegawa_wakatani_step import HasegawaWakataniStep
+from struphy.propagators.implicit_diffusion import ImplicitDiffusion
+from struphy.propagators.jxb_cold import JxBCold
+from struphy.propagators.magnetosonic import Magnetosonic
+from struphy.propagators.magnetosonic_uniform import MagnetosonicUniform
+from struphy.propagators.maxwell_weak_ampere import MaxwellWeakAmpere
+from struphy.propagators.ohm_cold import OhmCold
+from struphy.propagators.poisson_adiabatic_gyrokinetic import PoissonAdiabaticGyrokinetic
+from struphy.propagators.poisson_solve import PoissonSolve
+from struphy.propagators.pressure_coupling_6d import PressureCoupling6D
+from struphy.propagators.push_deterministic_diffusion import PushDeterministicDiffusion
+from struphy.propagators.push_eta import PushEta
+from struphy.propagators.push_eta_pc import PushEtaPC
+from struphy.propagators.push_guiding_center_bx_estar import PushGuidingCenterBxEstar
+from struphy.propagators.push_guiding_center_parallel import PushGuidingCenterParallel
+from struphy.propagators.push_random_diffusion import PushRandomDiffusion
+from struphy.propagators.push_vin_efield import PushVinEfield
+from struphy.propagators.push_vin_sph_pressure import PushVinSPHpressure
+from struphy.propagators.push_vin_viscous_potential import PushVinViscousPotential
+from struphy.propagators.push_vxb import PushVxB
+from struphy.propagators.shear_alfven_b1 import ShearAlfvenB1
+from struphy.propagators.shear_alfven_current_coupling_5d import ShearAlfvenCurrentCoupling5D
+from struphy.propagators.shear_alfven_propagator import ShearAlfvenPropagator
+from struphy.propagators.time_dependent_source import TimeDependentSource
+from struphy.propagators.two_fluid_quasi_neutral_full import TwoFluidQuasiNeutralFull
+from struphy.propagators.variational_density_evolve import VariationalDensityEvolve
+from struphy.propagators.variational_entropy_evolve import VariationalEntropyEvolve
+from struphy.propagators.variational_mag_field_evolve import VariationalMagFieldEvolve
+from struphy.propagators.variational_momentum_advection import VariationalMomentumAdvection
+from struphy.propagators.variational_pb_evolve import VariationalPBEvolve
+from struphy.propagators.variational_qb_evolve import VariationalQBEvolve
+from struphy.propagators.variational_resistivity import VariationalResistivity
+from struphy.propagators.variational_viscosity import VariationalViscosity
+from struphy.propagators.vlasov_ampere_coupling import VlasovAmpereCoupling
 
-# __all__ = [
-#     "VlasovAmpere",
-#     "EfieldWeights",
-#     "PressureCoupling6D",
-#     "CurrentCoupling6DCurrent",
-#     "CurrentCoupling5DCurlb",
-#     "CurrentCoupling5DGradB",
-#     "Maxwell",
-#     "OhmCold",
-#     "JxBCold",
-#     "ShearAlfven",
-#     "ShearAlfvenB1",
-#     "Hall",
-#     "Magnetosonic",
-#     "MagnetosonicUniform",
-#     "FaradayExtended",
-#     "CurrentCoupling6DDensity",
-#     "ShearAlfvenCurrentCoupling5D",
-#     "CurrentCoupling5DDensity",
-#     "ImplicitDiffusion",
-#     "Poisson",
-#     "VariationalMomentumAdvection",
-#     "VariationalDensityEvolve",
-#     "VariationalEntropyEvolve",
-#     "VariationalMagFieldEvolve",
-#     "VariationalPBEvolve",
-#     "VariationalQBEvolve",
-#     "VariationalViscosity",
-#     "VariationalResistivity",
-#     "TimeDependentSource",
-#     "AdiabaticPhi",
-#     "HasegawaWakatani",
-#     "TwoFluidQuasiNeutralFull",
-#     "PushEta",
-#     "PushVxB",
-#     "PushVinEfield",
-#     "PushEtaPC",
-#     "PushGuidingCenterBxEstar",
-#     "PushGuidingCenterParallel",
-#     "PushDeterministicDiffusion",
-#     "PushRandomDiffusion",
-#     "PushVinSPHpressure",
-#     "PushVinViscousPotential",
-# ]
+__all__ = [
+    "AdiabaticPhi",
+    "CurlCurlSolve",
+    "CurrentCoupling5DCurlb",
+    "CurrentCoupling5DDensity",
+    "CurrentCoupling5DGradB",
+    "CurrentCoupling6DCurrent",
+    "CurrentCoupling6DDensity",
+    "EfieldWeightsCoupling",
+    "FaradayExtended",
+    "Hall",
+    "HasegawaWakataniStep",
+    "ImplicitDiffusion",
+    "JxBCold",
+    "Magnetosonic",
+    "MagnetosonicUniform",
+    "MaxwellWeakAmpere",
+    "OhmCold",
+    "PoissonAdiabaticGyrokinetic",
+    "PoissonSolve",
+    "PressureCoupling6D",
+    "PushDeterministicDiffusion",
+    "PushEta",
+    "PushEtaPC",
+    "PushGuidingCenterBxEstar",
+    "PushGuidingCenterParallel",
+    "PushRandomDiffusion",
+    "PushVinEfield",
+    "PushVinSPHpressure",
+    "PushVinViscousPotential",
+    "PushVxB",
+    "ShearAlfvenB1",
+    "ShearAlfvenCurrentCoupling5D",
+    "ShearAlfvenPropagator",
+    "TimeDependentSource",
+    "TwoFluidQuasiNeutralFull",
+    "VariationalDensityEvolve",
+    "VariationalEntropyEvolve",
+    "VariationalMagFieldEvolve",
+    "VariationalMomentumAdvection",
+    "VariationalPBEvolve",
+    "VariationalQBEvolve",
+    "VariationalResistivity",
+    "VariationalViscosity",
+    "VlasovAmpereCoupling",
+]


### PR DESCRIPTION
**Solves the following issue(s):**

Closes #171, #172.

Reformatted the init files and added a `struphy build-init-files` to rebuild them after adding new models or propagators.

In the near future, I think we can completely get rid of the `struphy format` command, and just use `ruff format` for formatting and `ruff check` for linting instead.
