### PR TITLE
Added `save_restart: bool = True`

### DIFF
--- a/src/struphy/io/options.py
+++ b/src/struphy/io/options.py
@@ -324,6 +324,13 @@ class EnvironmentOptions(OptionsBase):
     save_step : int
         When to save data output: every time step (save_step=1), every second time step (save_step=2), etc (default=1).
 
+    save_restart : bool
+        Whether to write the restart checkpoint (full marker arrays and FEEC
+        restart coefficients, written once at setup and once at the end of
+        the run). Restart data can dominate the run time for large particle
+        counts; set to ``False`` to skip it when restart capability isn't
+        needed, e.g. for pure timing/benchmark runs (default=True).
+
     sort_step: int, optional
         Sort markers in memory every N time steps (default=0, which means markers are sorted only at the start of simulation)
 
@@ -342,6 +349,7 @@ class EnvironmentOptions(OptionsBase):
     restart: bool = False
     max_runtime: int = 300
     save_step: int = 1
+    save_restart: bool = True
     sort_step: int = 0
     num_clones: int = 1
     profiling_activated: bool = False

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -1370,18 +1370,19 @@ self.time_state["index"][0]={int(self.time_state["index"][0])}
                         file[key_field].attrs["pads"] = DataContainer._as_numpy_array(spline.pads)
 
                     # save numpy array to be updated only at the end of the simulation for restart.
-                    key_field_restart = os.path.join(species_path_restart, variable)
+                    if self.env.save_restart:
+                        key_field_restart = os.path.join(species_path_restart, variable)
 
-                    if isinstance(spline.vector_stencil, StencilVector):
-                        data.add_data(
-                            {key_field_restart: spline.vector_stencil._data},
-                        )
-                    else:
-                        for n in range(3):
-                            key_component_restart = os.path.join(key_field_restart, str(n + 1))
+                        if isinstance(spline.vector_stencil, StencilVector):
                             data.add_data(
-                                {key_component_restart: spline.vector_stencil[n]._data},
+                                {key_field_restart: spline.vector_stencil._data},
                             )
+                        else:
+                            for n in range(3):
+                                key_component_restart = os.path.join(key_field_restart, str(n + 1))
+                                data.add_data(
+                                    {key_component_restart: spline.vector_stencil[n]._data},
+                                )
 
             # save kinetic data in group 'kinetic/'
             for name, species in self.model.particle_species.items():
@@ -1393,10 +1394,11 @@ self.time_state["index"][0]={int(self.time_state["index"][0])}
                     assert isinstance(obj, Particles)
 
                 key_spec = os.path.join("kinetic", name)
-                key_spec_restart = os.path.join("restart", name)
 
                 # restart data
-                data.add_data({key_spec_restart: obj.markers})
+                if self.env.save_restart:
+                    key_spec_restart = os.path.join("restart", name)
+                    data.add_data({key_spec_restart: obj.markers})
 
                 # marker data
                 key_mks = os.path.join(key_spec, "markers")


### PR DESCRIPTION
Added a switch in `EnvironmentOptions` that lets you turn off writing of restart checkpoint data, this is convenient for benchmarking.