### PR TITLE
Add auto parallelization

### DIFF
--- a/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
+++ b/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
@@ -1,9 +1,10 @@
 """Benchmark domain-decomposition masks for a cylindrical ToyDrift PIC case.
 
 This is an intentionally anisotropic case: the logical grid has many radial
-cells and fewer azimuthal cells, while particles are loaded and sorted in the
-cylindrical domain.  On the reference 8-rank run, the mask ``(True, False,
-False)`` was about 32% faster than the default ``(True, True, True)`` mask.
+cells (512) and fewer azimuthal cells (16), while particles are loaded and
+sorted in the cylindrical domain.  On the reference 8-rank run, automatic
+selection prefers radial-only decomposition and was about 30% faster than the
+default ``(True, True, True)`` mask.  The exact speedup is machine-dependent.
 
 Run from the repository root, for example::
 
@@ -39,7 +40,7 @@ from struphy.models import ToyDrift
 from struphy.topology import optimize_domain_decomposition
 
 
-NUM_ELEMENTS = (128, 16, 1)
+NUM_ELEMENTS = (512, 16, 1)
 DEFAULT_MASK = (True, True, True)
 
 
@@ -86,16 +87,20 @@ def run_one_step(mask: tuple[bool, bool, bool], output_dir: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--id", type=int, default=0, help="Unique profiling-run identifier.")
     parser.add_argument("--warmups", type=int, default=1)
     parser.add_argument("--repetitions", type=int, default=2)
-    parser.add_argument("--output", default="benchmark_domain_decomposition")
-    args = parser.parse_args()
+    parser.add_argument("--output", default=None)
+    args, _ = parser.parse_known_args()
+
+    output = args.output or f"benchmark_domain_decomposition_{args.id:02d}"
 
     logging.getLogger("struphy").setLevel(logging.ERROR)
     result = optimize_domain_decomposition(
         NUM_ELEMENTS,
-        lambda mask: run_one_step(mask, args.output),
+        lambda mask: run_one_step(mask, output),
         comm=MPI.COMM_WORLD,
+        min_local_elements=(2, 2, 1),
         warmups=args.warmups,
         repetitions=args.repetitions,
     )

--- a/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
+++ b/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
@@ -10,10 +10,9 @@ Run from the repository root, for example::
 
     mpirun -n 8 python profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
 
-The benchmark times allocation plus one call to ``model.integrate``.  This
-keeps the example independent of the optional simulation profiling wrapper;
-the decomposition comparison itself is still performed by the public
-optimizer.
+The benchmark times one ``Simulation.run(one_time_step=True)`` call, including
+allocation, output setup, and profiling.  The decomposition comparison itself
+is performed by the public optimizer.
 """
 
 import argparse
@@ -42,9 +41,15 @@ from struphy.topology import optimize_domain_decomposition
 
 NUM_ELEMENTS = (512, 16, 1)
 DEFAULT_MASK = (True, True, True)
+WARMUPS = 1
+REPETITIONS = 2
 
 
-def run_one_step(mask: tuple[bool, bool, bool], output_dir: str) -> None:
+def run_one_step(
+    mask: tuple[bool, bool, bool],
+    output_dir: str,
+    num_elements: tuple[int, int, int],
+) -> None:
     """Build one candidate and perform one allocation/integration step."""
     model = ToyDrift(epsilon=1.0, alpha=1.0, base_units=BaseUnits(kBT=1.0))
     domain = domains.HollowCylinder(a1=1.0, a2=10.0, Lz=10.0)
@@ -55,7 +60,7 @@ def run_one_step(mask: tuple[bool, bool, bool], output_dir: str) -> None:
         weights_params=WeightsParameters(control_variate=True, reject_weights=True, threshold=0.0001),
         boundary_params=BoundaryParameters(),
         sorting_params=SortingParameters(
-            boxes_per_dim=NUM_ELEMENTS,
+            boxes_per_dim=num_elements,
             do_sort=True,
             sorting_frequency=1,
         ),
@@ -75,34 +80,30 @@ def run_one_step(mask: tuple[bool, bool, bool], output_dir: str) -> None:
         time_opts=Time(dt=0.01, Tend=0.01, split_algo="LieTrotter"),
         domain=domain,
         equil=equil,
-        grid=grids.TensorProductGrid(num_elements=NUM_ELEMENTS, mpi_dims_mask=mask),
+        grid=grids.TensorProductGrid(num_elements=num_elements, mpi_dims_mask=mask),
         derham_opts=DerhamOptions(
             degree=(2, 2, 1),
             bcs=(("dirichlet", "dirichlet"), None, None),
         ),
     )
-    sim.allocate()
-    sim.model.integrate(sim.time_opts.dt, sim.time_opts.split_algo)
+    sim.run(one_time_step=True, profiling_activated=True)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--id", type=int, default=0, help="Unique profiling-run identifier.")
-    parser.add_argument("--warmups", type=int, default=1)
-    parser.add_argument("--repetitions", type=int, default=2)
-    parser.add_argument("--output", default=None)
     args, _ = parser.parse_known_args()
 
-    output = args.output or f"benchmark_domain_decomposition_{args.id:02d}"
+    output = f"sim_{args.id:02d}"
 
     logging.getLogger("struphy").setLevel(logging.ERROR)
     result = optimize_domain_decomposition(
         NUM_ELEMENTS,
-        lambda mask: run_one_step(mask, output),
+        lambda mask: run_one_step(mask, output, NUM_ELEMENTS),
         comm=MPI.COMM_WORLD,
         min_local_elements=(2, 2, 1),
-        warmups=args.warmups,
-        repetitions=args.repetitions,
+        warmups=WARMUPS,
+        repetitions=REPETITIONS,
     )
 
     if MPI.COMM_WORLD.Get_rank() == 0:

--- a/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
+++ b/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
@@ -38,7 +38,6 @@ from struphy import (
 from struphy.models import ToyDrift
 from struphy.topology import optimize_domain_decomposition
 
-
 NUM_ELEMENTS = (512, 16, 1)
 DEFAULT_MASK = (True, True, True)
 WARMUPS = 1
@@ -111,9 +110,7 @@ def main() -> None:
         for timing in result.timings:
             print(f"{timing.mask}: {timing.seconds:.6f} s")
 
-        default = next(
-            timing.seconds for timing in result.timings if timing.mask == DEFAULT_MASK
-        )
+        default = next(timing.seconds for timing in result.timings if timing.mask == DEFAULT_MASK)
         speedup = default / min(timing.seconds for timing in result.timings)
         print(f"speedup over default: {speedup:.2f}x ({(speedup - 1.0) * 100:.1f}%)")
 

--- a/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
+++ b/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
@@ -1,0 +1,118 @@
+"""Benchmark domain-decomposition masks for a cylindrical ToyDrift PIC case.
+
+This is an intentionally anisotropic case: the logical grid has many radial
+cells and fewer azimuthal cells, while particles are loaded and sorted in the
+cylindrical domain.  On the reference 8-rank run, the mask ``(True, False,
+False)`` was about 32% faster than the default ``(True, True, True)`` mask.
+
+Run from the repository root, for example::
+
+    mpirun -n 8 python profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
+
+The benchmark times allocation plus one call to ``model.integrate``.  This
+keeps the example independent of the optional simulation profiling wrapper;
+the decomposition comparison itself is still performed by the public
+optimizer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from feectools.ddm.mpi import mpi as MPI
+
+from struphy import (
+    BaseUnits,
+    BoundaryParameters,
+    DerhamOptions,
+    EnvironmentOptions,
+    LoadingParameters,
+    Simulation,
+    SortingParameters,
+    Time,
+    WeightsParameters,
+    domains,
+    equils,
+    grids,
+    maxwellians,
+)
+from struphy.models import ToyDrift
+from struphy.topology import optimize_domain_decomposition
+
+
+NUM_ELEMENTS = (128, 16, 1)
+DEFAULT_MASK = (True, True, True)
+
+
+def run_one_step(mask: tuple[bool, bool, bool], output_dir: str) -> None:
+    """Build one candidate and perform one allocation/integration step."""
+    model = ToyDrift(epsilon=1.0, alpha=1.0, base_units=BaseUnits(kBT=1.0))
+    domain = domains.HollowCylinder(a1=1.0, a2=10.0, Lz=10.0)
+    equil = equils.HomogenSlab()
+
+    model.kinetic_ions.set_markers(
+        loading_params=LoadingParameters(ppc=50, loading="sobol_standard", spatial="disc"),
+        weights_params=WeightsParameters(control_variate=True, reject_weights=True, threshold=0.0001),
+        boundary_params=BoundaryParameters(),
+        sorting_params=SortingParameters(
+            boxes_per_dim=NUM_ELEMENTS,
+            do_sort=True,
+            sorting_frequency=1,
+        ),
+        bufsize=2.0,
+    )
+    model.kinetic_ions.var.add_background(
+        maxwellians.GyroMaxwellian2D(n=(0.0, None), B0=2.0),
+    )
+
+    sim = Simulation(
+        model=model,
+        env=EnvironmentOptions(
+            out_folders=output_dir,
+            sim_folder="mask_" + "".join("1" if value else "0" for value in mask),
+            restart=False,
+        ),
+        time_opts=Time(dt=0.01, Tend=0.01, split_algo="LieTrotter"),
+        domain=domain,
+        equil=equil,
+        grid=grids.TensorProductGrid(num_elements=NUM_ELEMENTS, mpi_dims_mask=mask),
+        derham_opts=DerhamOptions(
+            degree=(2, 2, 1),
+            bcs=(("dirichlet", "dirichlet"), None, None),
+        ),
+    )
+    sim.allocate()
+    sim.model.integrate(sim.time_opts.dt, sim.time_opts.split_algo)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=2)
+    parser.add_argument("--output", default="benchmark_domain_decomposition")
+    args = parser.parse_args()
+
+    logging.getLogger("struphy").setLevel(logging.ERROR)
+    result = optimize_domain_decomposition(
+        NUM_ELEMENTS,
+        lambda mask: run_one_step(mask, args.output),
+        comm=MPI.COMM_WORLD,
+        warmups=args.warmups,
+        repetitions=args.repetitions,
+    )
+
+    if MPI.COMM_WORLD.Get_rank() == 0:
+        print(f"best mask: {result.best_mask}")
+        for timing in result.timings:
+            print(f"{timing.mask}: {timing.seconds:.6f} s")
+
+        default = next(
+            timing.seconds for timing in result.timings if timing.mask == DEFAULT_MASK
+        )
+        speedup = default / min(timing.seconds for timing in result.timings)
+        print(f"speedup over default: {speedup:.2f}x ({(speedup - 1.0) * 100:.1f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
+++ b/profiling/examples/ToyGyrokinetic/diocotron_instability/benchmark_domain_decomposition.py
@@ -15,8 +15,6 @@ the decomposition comparison itself is still performed by the public
 optimizer.
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 

--- a/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
+++ b/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
@@ -1,0 +1,123 @@
+"""Benchmark clone versus spatial decomposition for a small Vlasov case.
+
+The benchmark keeps the physical grid fixed and compares every valid pair of
+``(num_clones, mpi_dims_mask)`` choices.  The deliberately small 4-by-4 grid
+keeps one-clone spatial decompositions valid while making clone-heavy choices
+available for comparison.
+
+Run from the repository root with, for example::
+
+    mpirun -n 4 python profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from feectools.ddm.mpi import mpi as MPI
+
+from struphy import (
+    BaseUnits,
+    BoundaryParameters,
+    DerhamOptions,
+    EnvironmentOptions,
+    LoadingParameters,
+    Simulation,
+    SortingParameters,
+    Time,
+    WeightsParameters,
+    domains,
+    equils,
+    grids,
+    maxwellians,
+)
+from struphy.models import LinearMHDVlasovCC
+from struphy.topology import optimize_parallel_configuration
+
+
+NUM_ELEMENTS = (8, 4, 1)
+DEGREE = (2, 2, 1)
+PPC = 2000
+WARMUPS = 0
+REPETITIONS = 1
+TIME_STEPS = 5
+
+
+def run_one_step(num_clones: int, mask: tuple[bool, bool, bool], output_dir: str) -> None:
+    model = LinearMHDVlasovCC(hot_epsilon=1.0)
+    for propagator in (
+        model.propagators.couple_dens,
+        model.propagators.shear_alf,
+        model.propagators.couple_curr,
+        model.propagators.push_eta,
+        model.propagators.push_vxb,
+        model.propagators.mag_sonic,
+    ):
+        propagator.options = propagator.Options()
+    model.energetic_ions.var.add_background(maxwellians.Maxwellian3D(n=(1.0, None)))
+    model.energetic_ions.set_markers(
+        loading_params=LoadingParameters(ppc=PPC, seed=1234),
+        weights_params=WeightsParameters(control_variate=False),
+        boundary_params=BoundaryParameters(),
+        sorting_params=SortingParameters(boxes_per_dim=NUM_ELEMENTS, do_sort=True),
+        bufsize=0.4,
+    )
+
+    sim = Simulation(
+        model=model,
+        env=EnvironmentOptions(
+            out_folders=output_dir,
+            sim_folder=f"clones_{num_clones}_mask_{''.join('1' if value else '0' for value in mask)}",
+            num_clones=num_clones,
+            restart=False,
+            save_restart=False,
+        ),
+        time_opts=Time(dt=0.05, Tend=TIME_STEPS * 0.05),
+        domain=domains.Cuboid(r1=12.56),
+        equil=equils.HomogenSlab(),
+        grid=grids.TensorProductGrid(num_elements=NUM_ELEMENTS, mpi_dims_mask=mask),
+        derham_opts=DerhamOptions(degree=DEGREE),
+    )
+    sim.run(profiling_activated=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--id", type=int, default=0, help="Unique profiling-run identifier.")
+    args, _ = parser.parse_known_args()
+
+    output = f"sim_{args.id:02d}"
+    logging.getLogger("struphy").setLevel(logging.ERROR)
+    result = optimize_parallel_configuration(
+        NUM_ELEMENTS,
+        lambda num_clones, mask: run_one_step(num_clones, mask, output),
+        comm=MPI.COMM_WORLD,
+        mask_pattern=(True, 1, 1),
+        min_local_elements=DEGREE,
+        warmups=WARMUPS,
+        repetitions=REPETITIONS,
+    )
+
+    if MPI.COMM_WORLD.Get_rank() == 0:
+        print(f"best configuration: clones={result.best_num_clones}, mask={result.best_mask}")
+        for timing in result.timings:
+            print(
+                f"clones={timing.num_clones}, mask={timing.mask}: "
+                f"{timing.seconds:.6f} s"
+            )
+
+        one_clone = [timing for timing in result.timings if timing.num_clones == 1]
+        if one_clone:
+            baseline = min(timing.seconds for timing in one_clone)
+            speedup = baseline / min(timing.seconds for timing in result.timings)
+            print(
+                "speedup over best one-clone configuration under mask pattern: "
+                f"{speedup:.2f}x ({(speedup - 1.0) * 100:.1f}%)"
+            )
+        else:
+            print("one-clone configuration: unavailable under mask pattern")
+
+
+if __name__ == "__main__":
+    main()

--- a/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
+++ b/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
@@ -35,7 +35,6 @@ from struphy import (
 from struphy.models import LinearMHDVlasovCC
 from struphy.topology import optimize_parallel_configuration, search_sorting_frequency
 
-
 NUM_ELEMENTS = (8, 4, 1)
 DEGREE = (2, 2, 1)
 PPC = 1000
@@ -53,9 +52,7 @@ def run_one_step(
     output_dir: str,
     sorting_frequency: int = 0,
 ) -> None:
-    build_simulation(num_clones, mask, output_dir, sorting_frequency).run(
-        profiling_activated=True
-    )
+    build_simulation(num_clones, mask, output_dir, sorting_frequency).run(profiling_activated=True)
 
 
 def build_simulation(
@@ -92,8 +89,7 @@ def build_simulation(
         env=EnvironmentOptions(
             out_folders=output_dir,
             sim_folder=(
-                f"clones_{num_clones}_mask_{''.join('1' if value else '0' for value in mask)}"
-                f"_sort_{sorting_frequency}"
+                f"clones_{num_clones}_mask_{''.join('1' if value else '0' for value in mask)}_sort_{sorting_frequency}"
             ),
             num_clones=num_clones,
             restart=False,
@@ -149,10 +145,7 @@ def main() -> None:
     if MPI.COMM_WORLD.Get_rank() == 0:
         print(f"best configuration: clones={result.best_num_clones}, mask={result.best_mask}")
         for timing in result.timings:
-            print(
-                f"clones={timing.num_clones}, mask={timing.mask}: "
-                f"{timing.seconds:.6f} s"
-            )
+            print(f"clones={timing.num_clones}, mask={timing.mask}: {timing.seconds:.6f} s")
 
         one_clone = [timing for timing in result.timings if timing.num_clones == 1]
         if one_clone:

--- a/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
+++ b/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
@@ -44,8 +44,6 @@ REPETITIONS = 1
 TIME_STEPS = 50
 DT = 0.05
 MAX_SORTING_FREQUENCY = 10
-SORTING_COARSE_STEP = 5
-SORTING_REFINEMENT_RADIUS = 2
 SORTING_REPETITIONS = 1
 
 
@@ -144,8 +142,6 @@ def main() -> None:
         MAX_SORTING_FREQUENCY,
         run_sorting_frequency,
         comm=MPI.COMM_WORLD,
-        coarse_step=SORTING_COARSE_STEP,
-        refinement_radius=SORTING_REFINEMENT_RADIUS,
         warmups=0,
         repetitions=SORTING_REPETITIONS,
     )

--- a/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
+++ b/profiling/examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py
@@ -1,7 +1,7 @@
 """Benchmark clone versus spatial decomposition for a small Vlasov case.
 
 The benchmark keeps the physical grid fixed and compares every valid pair of
-``(num_clones, mpi_dims_mask)`` choices.  The deliberately small 4-by-4 grid
+``(num_clones, mpi_dims_mask)`` choices.  The deliberately small 8-by-4 grid
 keeps one-clone spatial decompositions valid while making clone-heavy choices
 available for comparison.
 
@@ -33,18 +33,39 @@ from struphy import (
     maxwellians,
 )
 from struphy.models import LinearMHDVlasovCC
-from struphy.topology import optimize_parallel_configuration
+from struphy.topology import optimize_parallel_configuration, search_sorting_frequency
 
 
 NUM_ELEMENTS = (8, 4, 1)
 DEGREE = (2, 2, 1)
-PPC = 2000
+PPC = 1000
 WARMUPS = 0
 REPETITIONS = 1
-TIME_STEPS = 5
+TIME_STEPS = 50
+DT = 0.05
+MAX_SORTING_FREQUENCY = 10
+SORTING_COARSE_STEP = 5
+SORTING_REFINEMENT_RADIUS = 2
+SORTING_REPETITIONS = 1
 
 
-def run_one_step(num_clones: int, mask: tuple[bool, bool, bool], output_dir: str) -> None:
+def run_one_step(
+    num_clones: int,
+    mask: tuple[bool, bool, bool],
+    output_dir: str,
+    sorting_frequency: int = 0,
+) -> None:
+    build_simulation(num_clones, mask, output_dir, sorting_frequency).run(
+        profiling_activated=True
+    )
+
+
+def build_simulation(
+    num_clones: int,
+    mask: tuple[bool, bool, bool],
+    output_dir: str,
+    sorting_frequency: int = 0,
+) -> Simulation:
     model = LinearMHDVlasovCC(hot_epsilon=1.0)
     for propagator in (
         model.propagators.couple_dens,
@@ -60,7 +81,11 @@ def run_one_step(num_clones: int, mask: tuple[bool, bool, bool], output_dir: str
         loading_params=LoadingParameters(ppc=PPC, seed=1234),
         weights_params=WeightsParameters(control_variate=False),
         boundary_params=BoundaryParameters(),
-        sorting_params=SortingParameters(boxes_per_dim=NUM_ELEMENTS, do_sort=True),
+        sorting_params=SortingParameters(
+            boxes_per_dim=NUM_ELEMENTS,
+            do_sort=True,
+            sorting_frequency=sorting_frequency,
+        ),
         bufsize=0.4,
     )
 
@@ -68,18 +93,21 @@ def run_one_step(num_clones: int, mask: tuple[bool, bool, bool], output_dir: str
         model=model,
         env=EnvironmentOptions(
             out_folders=output_dir,
-            sim_folder=f"clones_{num_clones}_mask_{''.join('1' if value else '0' for value in mask)}",
+            sim_folder=(
+                f"clones_{num_clones}_mask_{''.join('1' if value else '0' for value in mask)}"
+                f"_sort_{sorting_frequency}"
+            ),
             num_clones=num_clones,
             restart=False,
             save_restart=False,
         ),
-        time_opts=Time(dt=0.05, Tend=TIME_STEPS * 0.05),
+        time_opts=Time(dt=DT, Tend=TIME_STEPS * DT),
         domain=domains.Cuboid(r1=12.56),
         equil=equils.HomogenSlab(),
         grid=grids.TensorProductGrid(num_elements=NUM_ELEMENTS, mpi_dims_mask=mask),
         derham_opts=DerhamOptions(degree=DEGREE),
     )
-    sim.run(profiling_activated=True)
+    return sim
 
 
 def main() -> None:
@@ -97,6 +125,29 @@ def main() -> None:
         min_local_elements=DEGREE,
         warmups=WARMUPS,
         repetitions=REPETITIONS,
+    )
+
+    sorting_simulations = {
+        frequency: build_simulation(
+            result.best_num_clones,
+            result.best_mask,
+            output,
+            sorting_frequency=frequency,
+        )
+        for frequency in range(MAX_SORTING_FREQUENCY + 1)
+    }
+
+    def run_sorting_frequency(frequency: int) -> None:
+        sorting_simulations[frequency].run(profiling_activated=True)
+
+    sorting_result = search_sorting_frequency(
+        MAX_SORTING_FREQUENCY,
+        run_sorting_frequency,
+        comm=MPI.COMM_WORLD,
+        coarse_step=SORTING_COARSE_STEP,
+        refinement_radius=SORTING_REFINEMENT_RADIUS,
+        warmups=0,
+        repetitions=SORTING_REPETITIONS,
     )
 
     if MPI.COMM_WORLD.Get_rank() == 0:
@@ -117,6 +168,10 @@ def main() -> None:
             )
         else:
             print("one-clone configuration: unavailable under mask pattern")
+
+        print(f"best sorting frequency: {sorting_result.best_value}")
+        for timing in sorting_result.timings:
+            print(f"sorting_frequency={timing.value}: {timing.seconds:.6f} s")
 
 
 if __name__ == "__main__":

--- a/profiling/submit_domain_decomposition.py
+++ b/profiling/submit_domain_decomposition.py
@@ -22,11 +22,7 @@ def main() -> None:
 
     script_dir = Path(__file__).resolve().parent
     benchmark = (
-        script_dir
-        / "examples"
-        / "ToyGyrokinetic"
-        / "diocotron_instability"
-        / "benchmark_domain_decomposition.py"
+        script_dir / "examples" / "ToyGyrokinetic" / "diocotron_instability" / "benchmark_domain_decomposition.py"
     )
 
     profiling_case = ProfilingCase(

--- a/profiling/submit_domain_decomposition.py
+++ b/profiling/submit_domain_decomposition.py
@@ -1,0 +1,54 @@
+"""Submit the anisotropic auto-domain-decomposition benchmark.
+
+Each profiling run benchmarks all valid ``mpi_dims_mask`` choices for the
+512-by-16 ToyDrift diocotron case and records the fastest choice relative to
+the default ``(True, True, True)`` decomposition.
+"""
+
+import argparse
+from pathlib import Path
+
+from profiling_job import ProfilingCase
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload packaged profiling results to the profiling-data repository.",
+    )
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    benchmark = (
+        script_dir
+        / "examples"
+        / "ToyGyrokinetic"
+        / "diocotron_instability"
+        / "benchmark_domain_decomposition.py"
+    )
+
+    profiling_case = ProfilingCase(
+        label="domain_decomposition",
+        name="Automatic domain-decomposition benchmark",
+        description=(
+            "Anisotropic 512x16 ToyDrift diocotron case comparing automatic "
+            "MPI decomposition against (True, True, True)."
+        ),
+        physics_problem="Diocotron instability in a non-neutral plasma.",
+        struphy_model_used="ToyDrift",
+        params_source=benchmark,
+        language="fortran",
+        compiler="GNU",
+        upload=args.upload,
+    )
+
+    for num_tasks in (8, 16, 32):
+        profiling_case.launch(num_tasks)
+
+    profiling_case.finalize_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/profiling/submit_vlasov_sorting_frequency.py
+++ b/profiling/submit_vlasov_sorting_frequency.py
@@ -23,13 +23,7 @@ def main() -> None:
     args = parser.parse_args()
 
     script_dir = Path(__file__).resolve().parent
-    benchmark = (
-        script_dir
-        / "examples"
-        / "Vlasov"
-        / "clone_decomposition"
-        / "benchmark_vlasov_clones.py"
-    )
+    benchmark = script_dir / "examples" / "Vlasov" / "clone_decomposition" / "benchmark_vlasov_clones.py"
 
     profiling_case = ProfilingCase(
         label="vlasov_sorting_frequency",

--- a/profiling/submit_vlasov_sorting_frequency.py
+++ b/profiling/submit_vlasov_sorting_frequency.py
@@ -1,0 +1,56 @@
+"""Submit the hybrid Vlasov sorting-frequency benchmark.
+
+The benchmark runs the small ``LinearMHDVlasovCC`` case and measures the
+candidate sorting frequencies hardcoded in
+``examples/Vlasov/clone_decomposition/benchmark_vlasov_clones.py``.  The
+benchmark also records the best clone/decomposition configuration first, then
+reuses it while tuning sorting frequency.
+"""
+
+import argparse
+from pathlib import Path
+
+from profiling_job import ProfilingCase
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload packaged profiling results to the profiling-data repository.",
+    )
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    benchmark = (
+        script_dir
+        / "examples"
+        / "Vlasov"
+        / "clone_decomposition"
+        / "benchmark_vlasov_clones.py"
+    )
+
+    profiling_case = ProfilingCase(
+        label="vlasov_sorting_frequency",
+        name="Hybrid Vlasov sorting-frequency benchmark",
+        description=(
+            "Small LinearMHDVlasovCC case comparing hardcoded particle "
+            "sorting frequencies after selecting the best parallel configuration."
+        ),
+        physics_problem="Hybrid MHD-fluid and energetic-ion Vlasov evolution.",
+        struphy_model_used="LinearMHDVlasovCC",
+        params_source=benchmark,
+        language="fortran",
+        compiler="GNU",
+        upload=args.upload,
+    )
+
+    for num_tasks in (4, 8, 16):
+        profiling_case.launch(num_tasks)
+
+    profiling_case.finalize_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/struphy/simulation/sim.py
+++ b/src/struphy/simulation/sim.py
@@ -760,13 +760,28 @@ class Simulation(SimulationBase):
                     logger.info("")
                     break
 
-                if self.env.sort_step and int(self.time_state["index"][0]) % self.env.sort_step == 0:
+                sort_functions = []
+                particles_to_sort = []
+                particle_objects = [
+                    variable.particles
+                    for species in self.model.particle_species.values()
+                    for variable in species.variables.values()
+                    if isinstance(variable, PICVariable | SPHVariable)
+                ]
+                for val in particle_objects:
+                    # An explicit EnvironmentOptions.sort_step overrides the
+                    # per-particle SortingParameters frequency. Otherwise,
+                    # honor the frequency configured for this particle species.
+                    frequency = self.env.sort_step or val.sorting_params.sorting_frequency
+                    if frequency and int(self.time_state["index"][0]) % frequency == 0:
+                        particles_to_sort.append(val)
+                        sort_functions.append(val.do_sort)
+
+                if particles_to_sort:
                     t0 = time.time()
-                    sort_functions = [val.do_sort for val in self.model.pointer.values() if isinstance(val, Particles)]
                     with ProfileManager.profile_region("sort particles", functions=sort_functions):
-                        for key, val in self.model.pointer.items():
-                            if isinstance(val, Particles):
-                                val.do_sort()
+                        for val in particles_to_sort:
+                            val.do_sort()
                     t1 = time.time()
                     message = "Particles sorted | wall clock [s]: {0:8.4f} | sorting duration [s]: {1:8.4f}".format(
                         run_time_now * 60,

--- a/src/struphy/topology/__init__.py
+++ b/src/struphy/topology/__init__.py
@@ -9,6 +9,14 @@ from .domain_decomposition import (
     optimize_domain_decomposition,
     optimize_parallel_configuration,
 )
+from .autotuning import (
+    ParameterOptimization,
+    ParameterTiming,
+    optimize_integer_parameter,
+    optimize_sorting_frequency,
+    search_integer_parameter,
+    search_sorting_frequency,
+)
 
 __all__ = [
     "DomainDecompositionOptimization",
@@ -20,4 +28,10 @@ __all__ = [
     "candidate_clone_counts",
     "optimize_domain_decomposition",
     "optimize_parallel_configuration",
+    "ParameterOptimization",
+    "ParameterTiming",
+    "optimize_integer_parameter",
+    "optimize_sorting_frequency",
+    "search_integer_parameter",
+    "search_sorting_frequency",
 ]

--- a/src/struphy/topology/__init__.py
+++ b/src/struphy/topology/__init__.py
@@ -1,6 +1,7 @@
 from .domain_decomposition import (
     DomainDecompositionOptimization,
     DomainDecompositionTiming,
+    MaskPattern,
     candidate_masks,
     optimize_domain_decomposition,
 )
@@ -8,6 +9,7 @@ from .domain_decomposition import (
 __all__ = [
     "DomainDecompositionOptimization",
     "DomainDecompositionTiming",
+    "MaskPattern",
     "candidate_masks",
     "optimize_domain_decomposition",
 ]

--- a/src/struphy/topology/__init__.py
+++ b/src/struphy/topology/__init__.py
@@ -2,14 +2,22 @@ from .domain_decomposition import (
     DomainDecompositionOptimization,
     DomainDecompositionTiming,
     MaskPattern,
+    ParallelConfigurationOptimization,
+    ParallelConfigurationTiming,
     candidate_masks,
+    candidate_clone_counts,
     optimize_domain_decomposition,
+    optimize_parallel_configuration,
 )
 
 __all__ = [
     "DomainDecompositionOptimization",
     "DomainDecompositionTiming",
     "MaskPattern",
+    "ParallelConfigurationOptimization",
+    "ParallelConfigurationTiming",
     "candidate_masks",
+    "candidate_clone_counts",
     "optimize_domain_decomposition",
+    "optimize_parallel_configuration",
 ]

--- a/src/struphy/topology/__init__.py
+++ b/src/struphy/topology/__init__.py
@@ -1,14 +1,3 @@
-from .domain_decomposition import (
-    DomainDecompositionOptimization,
-    DomainDecompositionTiming,
-    MaskPattern,
-    ParallelConfigurationOptimization,
-    ParallelConfigurationTiming,
-    candidate_masks,
-    candidate_clone_counts,
-    optimize_domain_decomposition,
-    optimize_parallel_configuration,
-)
 from .autotuning import (
     ParameterOptimization,
     ParameterTiming,
@@ -16,6 +5,17 @@ from .autotuning import (
     optimize_sorting_frequency,
     search_integer_parameter,
     search_sorting_frequency,
+)
+from .domain_decomposition import (
+    DomainDecompositionOptimization,
+    DomainDecompositionTiming,
+    MaskPattern,
+    ParallelConfigurationOptimization,
+    ParallelConfigurationTiming,
+    candidate_clone_counts,
+    candidate_masks,
+    optimize_domain_decomposition,
+    optimize_parallel_configuration,
 )
 
 __all__ = [

--- a/src/struphy/topology/__init__.py
+++ b/src/struphy/topology/__init__.py
@@ -1,0 +1,13 @@
+from .domain_decomposition import (
+    DomainDecompositionOptimization,
+    DomainDecompositionTiming,
+    candidate_masks,
+    optimize_domain_decomposition,
+)
+
+__all__ = [
+    "DomainDecompositionOptimization",
+    "DomainDecompositionTiming",
+    "candidate_masks",
+    "optimize_domain_decomposition",
+]

--- a/src/struphy/topology/autotuning.py
+++ b/src/struphy/topology/autotuning.py
@@ -1,0 +1,167 @@
+"""Small empirical autotuning helpers for runtime configuration choices."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from feectools.ddm.mpi import mpi as MPI
+
+
+@dataclass(frozen=True)
+class ParameterTiming:
+    value: int
+    seconds: float
+
+
+@dataclass(frozen=True)
+class ParameterOptimization:
+    best_value: int
+    timings: tuple[ParameterTiming, ...]
+
+
+def optimize_integer_parameter(
+    values: Iterable[int],
+    step: Callable[[int], object],
+    *,
+    comm=None,
+    warmups: int = 1,
+    repetitions: int = 3,
+) -> ParameterOptimization:
+    """Select the fastest integer parameter using communicator-wide timings.
+
+    ``step(value)`` must be called collectively and should perform the same
+    fixed amount of simulation work for each candidate value.
+    """
+    if warmups < 0 or repetitions < 1:
+        raise ValueError("warmups must be non-negative and repetitions must be positive")
+    selected = tuple(dict.fromkeys(int(value) for value in values))
+    if not selected:
+        raise ValueError("at least one parameter value is required")
+    if any(value < 0 for value in selected):
+        raise ValueError("parameter values must be non-negative")
+    if comm is None:
+        comm = MPI.COMM_WORLD
+
+    timings = []
+    for value in selected:
+        for _ in range(warmups):
+            _barrier(comm)
+            step(value)
+        samples = []
+        for _ in range(repetitions):
+            _barrier(comm)
+            start = time.perf_counter()
+            step(value)
+            elapsed = time.perf_counter() - start
+            samples.append(_global_max(comm, elapsed))
+        _barrier(comm)
+        timings.append(ParameterTiming(value=value, seconds=sum(samples) / len(samples)))
+
+    best = min(timings, key=lambda timing: timing.seconds)
+    return ParameterOptimization(best_value=best.value, timings=tuple(timings))
+
+
+def optimize_sorting_frequency(
+    frequencies: Iterable[int],
+    step: Callable[[int], object],
+    *,
+    comm=None,
+    warmups: int = 1,
+    repetitions: int = 3,
+) -> ParameterOptimization:
+    """Select the fastest particle-sorting frequency.
+
+    Frequency ``0`` is supported and means that no periodic sorting is done;
+    the callback remains responsible for performing any initial sort required
+    by the simulation.
+    """
+    return optimize_integer_parameter(
+        frequencies,
+        step,
+        comm=comm,
+        warmups=warmups,
+        repetitions=repetitions,
+    )
+
+
+def search_integer_parameter(
+    lower: int,
+    upper: int,
+    step: Callable[[int], object],
+    *,
+    coarse_step: int = 4,
+    refinement_radius: int = 2,
+    comm=None,
+    warmups: int = 1,
+    repetitions: int = 3,
+) -> ParameterOptimization:
+    """Search an integer interval with a coarse pass and local refinement."""
+    if lower < 0 or upper < lower:
+        raise ValueError("expected 0 <= lower <= upper")
+    if coarse_step < 1 or refinement_radius < 0:
+        raise ValueError("coarse_step must be positive and refinement_radius non-negative")
+
+    coarse_values = list(range(lower, upper + 1, coarse_step))
+    if coarse_values[-1] != upper:
+        coarse_values.append(upper)
+    coarse_result = optimize_integer_parameter(
+        coarse_values,
+        step,
+        comm=comm,
+        warmups=warmups,
+        repetitions=repetitions,
+    )
+
+    fine_lower = max(lower, coarse_result.best_value - refinement_radius)
+    fine_upper = min(upper, coarse_result.best_value + refinement_radius)
+    fine_values = range(fine_lower, fine_upper + 1)
+    fine_result = optimize_integer_parameter(
+        fine_values,
+        step,
+        comm=comm,
+        warmups=warmups,
+        repetitions=repetitions,
+    )
+
+    timings = coarse_result.timings + tuple(
+        timing for timing in fine_result.timings if timing.value not in coarse_values
+    )
+    best = min(timings, key=lambda timing: timing.seconds)
+    return ParameterOptimization(best_value=best.value, timings=timings)
+
+
+def search_sorting_frequency(
+    upper: int,
+    step: Callable[[int], object],
+    *,
+    lower: int = 0,
+    coarse_step: int = 4,
+    refinement_radius: int = 2,
+    comm=None,
+    warmups: int = 1,
+    repetitions: int = 3,
+) -> ParameterOptimization:
+    """Adaptively search a sorting-frequency interval."""
+    return search_integer_parameter(
+        lower,
+        upper,
+        step,
+        coarse_step=coarse_step,
+        refinement_radius=refinement_radius,
+        comm=comm,
+        warmups=warmups,
+        repetitions=repetitions,
+    )
+
+
+def _barrier(comm) -> None:
+    if comm.Get_size() > 1:
+        comm.Barrier()
+
+
+def _global_max(comm, value: float) -> float:
+    if comm.Get_size() == 1:
+        return value
+    return float(comm.allreduce(value, op=MPI.MAX))

--- a/src/struphy/topology/autotuning.py
+++ b/src/struphy/topology/autotuning.py
@@ -91,43 +91,41 @@ def search_integer_parameter(
     upper: int,
     step: Callable[[int], object],
     *,
-    coarse_step: int = 4,
-    refinement_radius: int = 2,
     comm=None,
     warmups: int = 1,
     repetitions: int = 3,
 ) -> ParameterOptimization:
-    """Search an integer interval with a coarse pass and local refinement."""
+    """Search an approximately unimodal integer cost with ternary search."""
     if lower < 0 or upper < lower:
         raise ValueError("expected 0 <= lower <= upper")
-    if coarse_step < 1 or refinement_radius < 0:
-        raise ValueError("coarse_step must be positive and refinement_radius non-negative")
 
-    coarse_values = list(range(lower, upper + 1, coarse_step))
-    if coarse_values[-1] != upper:
-        coarse_values.append(upper)
-    coarse_result = optimize_integer_parameter(
-        coarse_values,
-        step,
-        comm=comm,
-        warmups=warmups,
-        repetitions=repetitions,
-    )
+    timings_by_value: dict[int, ParameterTiming] = {}
 
-    fine_lower = max(lower, coarse_result.best_value - refinement_radius)
-    fine_upper = min(upper, coarse_result.best_value + refinement_radius)
-    fine_values = range(fine_lower, fine_upper + 1)
-    fine_result = optimize_integer_parameter(
-        fine_values,
-        step,
-        comm=comm,
-        warmups=warmups,
-        repetitions=repetitions,
-    )
+    def measure(value: int) -> ParameterTiming:
+        if value not in timings_by_value:
+            result = optimize_integer_parameter(
+                (value,),
+                step,
+                comm=comm,
+                warmups=warmups,
+                repetitions=repetitions,
+            )
+            timings_by_value[value] = result.timings[0]
+        return timings_by_value[value]
 
-    timings = coarse_result.timings + tuple(
-        timing for timing in fine_result.timings if timing.value not in coarse_values
-    )
+    left, right = lower, upper
+    while right - left > 3:
+        first = left + (right - left) // 3
+        second = right - (right - left) // 3
+        if measure(first).seconds <= measure(second).seconds:
+            right = second - 1
+        else:
+            left = first + 1
+
+    for value in range(left, right + 1):
+        measure(value)
+
+    timings = tuple(timings_by_value.values())
     best = min(timings, key=lambda timing: timing.seconds)
     return ParameterOptimization(best_value=best.value, timings=timings)
 
@@ -137,8 +135,6 @@ def search_sorting_frequency(
     step: Callable[[int], object],
     *,
     lower: int = 0,
-    coarse_step: int = 4,
-    refinement_radius: int = 2,
     comm=None,
     warmups: int = 1,
     repetitions: int = 3,
@@ -148,8 +144,6 @@ def search_sorting_frequency(
         lower,
         upper,
         step,
-        coarse_step=coarse_step,
-        refinement_radius=refinement_radius,
         comm=comm,
         warmups=warmups,
         repetitions=repetitions,

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -9,13 +9,14 @@ step for a given mask.
 import itertools
 import time
 from dataclasses import dataclass
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Literal
 
 from feectools.ddm.mpi import mpi as MPI
 from feectools.ddm.partition import compute_dims
 
 Mask = tuple[bool, bool, bool]
 LocalMinimum = int | tuple[int, int, int]
+MaskPattern = tuple[bool | Literal["auto"], bool | Literal["auto"], bool | Literal["auto"]]
 
 
 @dataclass(frozen=True)
@@ -39,6 +40,7 @@ def candidate_masks(
     comm_size: int,
     *,
     min_local_elements: LocalMinimum = 1,
+    mask_pattern: MaskPattern | None = None,
 ) -> tuple[Mask, ...]:
     """Return valid non-empty ``mpi_dims_mask`` candidates.
 
@@ -64,10 +66,16 @@ def candidate_masks(
         raise ValueError("num_elements must contain positive values")
     if int(comm_size) > num_elements[0] * num_elements[1] * num_elements[2]:
         raise ValueError("comm_size cannot exceed the number of grid elements")
+    pattern = _normalize_mask_pattern(mask_pattern)
 
     masks: list[Mask] = []
     for mask in itertools.product((False, True), repeat=3):
         if not any(mask):
+            continue
+        if pattern is not None and any(
+            expected != "auto" and value != expected
+            for value, expected in zip(mask, pattern)
+        ):
             continue
         try:
             nprocs, blocksizes = compute_dims(comm_size, list(num_elements), mpi_dims_mask=list(mask))
@@ -94,6 +102,7 @@ def optimize_domain_decomposition(
     comm=None,
     masks: Iterable[Mask] | None = None,
     min_local_elements: LocalMinimum = 1,
+    mask_pattern: MaskPattern | None = None,
     warmups: int = 1,
     repetitions: int = 3,
 ) -> DomainDecompositionOptimization:
@@ -119,6 +128,10 @@ def optimize_domain_decomposition(
         Minimum number of elements in every local block. This can be one
         integer for all directions or a three-tuple for direction-specific
         requirements. For FEEC grids, pass the spline degree tuple.
+    mask_pattern
+        Optional per-direction constraint. Use ``True`` or ``False`` to fix a
+        direction and ``"auto"`` to let the optimizer vary it, e.g.
+        ``(True, "auto", "auto")``.
 
     Returns
     -------
@@ -143,6 +156,7 @@ def optimize_domain_decomposition(
             num_elements,
             comm_size,
             min_local_elements=min_local_elements,
+            mask_pattern=mask_pattern,
         )
     )
     selected_masks = tuple(valid_masks if masks is None else _validate_masks(masks, valid_masks))
@@ -179,6 +193,16 @@ def _validate_masks(masks: Iterable[Mask], valid_masks: set[Mask]) -> set[Mask]:
             raise ValueError(f"decomposition mask is not valid for this grid/MPI size: {mask!r}")
         selected.add(normalized)
     return selected
+
+
+def _normalize_mask_pattern(mask_pattern: MaskPattern | None) -> MaskPattern | None:
+    if mask_pattern is None:
+        return None
+    if len(mask_pattern) != 3:
+        raise ValueError("mask_pattern must contain exactly three dimensions")
+    if not all(value in (True, False, "auto") for value in mask_pattern):
+        raise ValueError("mask_pattern entries must be True, False, or 'auto'")
+    return mask_pattern
 
 
 def _barrier(comm) -> None:

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -15,6 +15,7 @@ from feectools.ddm.mpi import mpi as MPI
 from feectools.ddm.partition import compute_dims
 
 Mask = tuple[bool, bool, bool]
+LocalMinimum = int | tuple[int, int, int]
 
 
 @dataclass(frozen=True)
@@ -37,7 +38,7 @@ def candidate_masks(
     num_elements: tuple[int, int, int],
     comm_size: int,
     *,
-    min_local_elements: int = 1,
+    min_local_elements: LocalMinimum = 1,
 ) -> tuple[Mask, ...]:
     """Return valid non-empty ``mpi_dims_mask`` candidates.
 
@@ -51,7 +52,13 @@ def candidate_masks(
         raise ValueError("num_elements must contain exactly three dimensions")
     if comm_size < 1:
         raise ValueError("comm_size must be positive")
-    if min_local_elements < 1:
+    if isinstance(min_local_elements, int):
+        local_minimum = (min_local_elements,) * 3
+    else:
+        if len(min_local_elements) != 3:
+            raise ValueError("min_local_elements must contain exactly three dimensions")
+        local_minimum = tuple(int(value) for value in min_local_elements)
+    if any(value < 1 for value in local_minimum):
         raise ValueError("min_local_elements must be positive")
     if any(int(n) <= 0 for n in num_elements):
         raise ValueError("num_elements must contain positive values")
@@ -66,12 +73,13 @@ def candidate_masks(
             nprocs, blocksizes = compute_dims(comm_size, list(num_elements), mpi_dims_mask=list(mask))
         except (AssertionError, ValueError):
             continue
-        # ``compute_dims`` accepts a process grid whose local block would have
-        # zero cells in a short direction.  FEEC discretization cannot use
-        # such a grid, so reject it here before invoking the user callback.
+        # ``compute_dims`` accepts a process grid whose local block is too
+        # small in a short direction.  FEEC discretization cannot use such a
+        # grid (the required minimum is normally the spline degree), so reject
+        # it here before invoking the user callback.
         if any(
-            p > n or block < min_local_elements
-            for p, n, block in zip(nprocs, num_elements, blocksizes)
+            p > n or block < minimum
+            for p, n, block, minimum in zip(nprocs, num_elements, blocksizes, local_minimum)
         ):
             continue
         masks.append(mask)
@@ -85,7 +93,7 @@ def optimize_domain_decomposition(
     *,
     comm=None,
     masks: Iterable[Mask] | None = None,
-    min_local_elements: int = 1,
+    min_local_elements: LocalMinimum = 1,
     warmups: int = 1,
     repetitions: int = 3,
 ) -> DomainDecompositionOptimization:
@@ -107,6 +115,10 @@ def optimize_domain_decomposition(
     warmups, repetitions
         Number of discarded and measured calls per candidate.  The reported
         time is the average of the communicator-wide maximum time per call.
+    min_local_elements
+        Minimum number of elements in every local block. This can be one
+        integer for all directions or a three-tuple for direction-specific
+        requirements. For FEEC grids, pass the spline degree tuple.
 
     Returns
     -------

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -39,6 +39,35 @@ class DomainDecompositionOptimization:
     timings: tuple[DomainDecompositionTiming, ...]
 
 
+@dataclass(frozen=True)
+class ParallelConfigurationTiming:
+    """Measured wall time for one clone/decomposition configuration."""
+
+    num_clones: int
+    mask: Mask
+    seconds: float
+
+
+@dataclass(frozen=True)
+class ParallelConfigurationOptimization:
+    """Result of an empirical clone and domain-decomposition search."""
+
+    best_num_clones: int
+    best_mask: Mask
+    timings: tuple[ParallelConfigurationTiming, ...]
+
+
+def candidate_clone_counts(comm_size: int) -> tuple[int, ...]:
+    """Return clone counts that evenly divide the MPI communicator size."""
+    if comm_size < 1:
+        raise ValueError("comm_size must be positive")
+    return tuple(
+        clones
+        for clones in range(1, comm_size + 1)
+        if comm_size % clones == 0
+    )
+
+
 def candidate_masks(
     num_elements: tuple[int, int, int],
     comm_size: int,
@@ -205,6 +234,75 @@ def optimize_domain_decomposition(
 
     best = min(timings, key=lambda timing: timing.seconds)
     return DomainDecompositionOptimization(best_mask=best.mask, timings=tuple(timings))
+
+
+def optimize_parallel_configuration(
+    num_elements: tuple[int, int, int],
+    step: Callable[[int, Mask], object],
+    *,
+    comm=None,
+    clone_counts: Iterable[int] | None = None,
+    min_local_elements: LocalMinimum = 1,
+    mask_pattern: MaskPattern | None = None,
+    warmups: int = 1,
+    repetitions: int = 3,
+) -> ParallelConfigurationOptimization:
+    """Select the fastest clone count and spatial decomposition together.
+
+    ``step(num_clones, mask)`` must construct a fresh simulation using
+    ``EnvironmentOptions(num_clones=num_clones)`` and the supplied
+    ``mpi_dims_mask=mask``. It is called collectively by every world rank.
+    Spatial decomposition candidates are generated for the communicator size
+    inside one clone, ``comm_size // num_clones``.
+    """
+    if warmups < 0 or repetitions < 1:
+        raise ValueError("warmups must be non-negative and repetitions must be positive")
+    if comm is None:
+        comm = MPI.COMM_WORLD
+
+    comm_size = comm.Get_size()
+    valid_clone_counts = set(candidate_clone_counts(comm_size))
+    selected_clones = valid_clone_counts if clone_counts is None else set(clone_counts)
+    if not selected_clones:
+        raise ValueError("no clone counts were supplied")
+    if not selected_clones.issubset(valid_clone_counts):
+        raise ValueError("clone counts must be positive divisors of the MPI communicator size")
+
+    timings: list[ParallelConfigurationTiming] = []
+    for num_clones in sorted(selected_clones):
+        masks = candidate_masks(
+            num_elements,
+            comm_size // num_clones,
+            min_local_elements=min_local_elements,
+            mask_pattern=mask_pattern,
+        )
+        for mask in masks:
+            for _ in range(warmups):
+                _barrier(comm)
+                step(num_clones, mask)
+            samples = []
+            for _ in range(repetitions):
+                _barrier(comm)
+                start = time.perf_counter()
+                step(num_clones, mask)
+                samples.append(_global_max(comm, time.perf_counter() - start))
+            _barrier(comm)
+            timings.append(
+                ParallelConfigurationTiming(
+                    num_clones=num_clones,
+                    mask=mask,
+                    seconds=sum(samples) / len(samples),
+                )
+            )
+
+    if not timings:
+        raise ValueError("no valid clone/decomposition configurations were found")
+    best = min(timings, key=lambda timing: timing.seconds)
+    return ParallelConfigurationOptimization(
+        best_num_clones=best.num_clones,
+        best_mask=best.mask,
+        timings=tuple(timings),
+    )
 
 
 def _validate_masks(masks: Iterable[Mask], valid_masks: set[Mask]) -> set[Mask]:

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -1,0 +1,169 @@
+"""Small, empirical domain-decomposition optimization helpers.
+
+The current Struphy grid API exposes decomposition choices through
+``mpi_dims_mask``.  This module measures those choices without knowing
+anything about the model: the caller supplies a function which performs one
+step for a given mask.
+"""
+
+from __future__ import annotations
+
+import itertools
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from feectools.ddm.mpi import mpi as MPI
+from feectools.ddm.partition import compute_dims
+
+
+Mask = tuple[bool, bool, bool]
+
+
+@dataclass(frozen=True)
+class DomainDecompositionTiming:
+    """Measured wall time for one decomposition mask."""
+
+    mask: Mask
+    seconds: float
+
+
+@dataclass(frozen=True)
+class DomainDecompositionOptimization:
+    """Result of an empirical decomposition search."""
+
+    best_mask: Mask
+    timings: tuple[DomainDecompositionTiming, ...]
+
+
+def candidate_masks(
+    num_elements: tuple[int, int, int],
+    comm_size: int,
+) -> tuple[Mask, ...]:
+    """Return valid non-empty ``mpi_dims_mask`` candidates.
+
+    A candidate is retained when :func:`feectools.ddm.partition.compute_dims`
+    can construct a process grid for it.  The order is stable and starts with
+    one-dimensional decompositions, followed by two- and three-dimensional
+    decompositions.
+    """
+
+    if len(num_elements) != 3:
+        raise ValueError("num_elements must contain exactly three dimensions")
+    if comm_size < 1:
+        raise ValueError("comm_size must be positive")
+    if any(int(n) <= 0 for n in num_elements):
+        raise ValueError("num_elements must contain positive values")
+    if int(comm_size) > num_elements[0] * num_elements[1] * num_elements[2]:
+        raise ValueError("comm_size cannot exceed the number of grid elements")
+
+    masks: list[Mask] = []
+    for mask in itertools.product((False, True), repeat=3):
+        if not any(mask):
+            continue
+        try:
+            nprocs, blocksizes = compute_dims(comm_size, list(num_elements), mpi_dims_mask=list(mask))
+        except (AssertionError, ValueError):
+            continue
+        # ``compute_dims`` accepts a process grid whose local block would have
+        # zero cells in a short direction.  FEEC discretization cannot use
+        # such a grid, so reject it here before invoking the user callback.
+        if any(p > n or block < 1 for p, n, block in zip(nprocs, num_elements, blocksizes)):
+            continue
+        masks.append(mask)
+
+    return tuple(sorted(masks, key=lambda mask: (sum(mask), mask)))
+
+
+def optimize_domain_decomposition(
+    num_elements: tuple[int, int, int],
+    step: Callable[[Mask], object],
+    *,
+    comm=None,
+    masks: Iterable[Mask] | None = None,
+    warmups: int = 1,
+    repetitions: int = 3,
+) -> DomainDecompositionOptimization:
+    """Select the fastest decomposition by timing a supplied one-step call.
+
+    Parameters
+    ----------
+    num_elements
+        Global grid resolution, used to reject invalid masks.
+    step
+        Callable that constructs/configures the candidate decomposition and
+        performs exactly one timestep.  It is called collectively by all MPI
+        ranks for every candidate.
+    comm
+        MPI communicator.  Defaults to ``MPI.COMM_WORLD``.
+    masks
+        Optional explicit subset of masks.  By default all valid masks are
+        measured.
+    warmups, repetitions
+        Number of discarded and measured calls per candidate.  The reported
+        time is the average of the communicator-wide maximum time per call.
+
+    Returns
+    -------
+    DomainDecompositionOptimization
+        All measured times and the mask with the lowest average timestep time.
+
+    Notes
+    -----
+    This function does not reuse simulations between candidates.  A practical
+    ``step`` callback should therefore build a fresh simulation for its mask,
+    call ``sim.run(one_time_step=True)``, and clean up its output if needed.
+    """
+
+    if warmups < 0 or repetitions < 1:
+        raise ValueError("warmups must be non-negative and repetitions must be positive")
+
+    if comm is None:
+        comm = MPI.COMM_WORLD
+    comm_size = comm.Get_size()
+    valid_masks = set(candidate_masks(num_elements, comm_size))
+    selected_masks = tuple(valid_masks if masks is None else _validate_masks(masks, valid_masks))
+    if not selected_masks:
+        raise ValueError("no valid decomposition masks were supplied")
+    selected_masks = tuple(sorted(selected_masks, key=lambda mask: (sum(mask), mask)))
+
+    timings: list[DomainDecompositionTiming] = []
+    for mask in selected_masks:
+        for _ in range(warmups):
+            _barrier(comm)
+            step(mask)
+        samples = []
+        for _ in range(repetitions):
+            _barrier(comm)
+            start = time.perf_counter()
+            step(mask)
+            elapsed = time.perf_counter() - start
+            samples.append(_global_max(comm, elapsed))
+        _barrier(comm)
+        timings.append(DomainDecompositionTiming(mask=mask, seconds=sum(samples) / len(samples)))
+
+    best = min(timings, key=lambda timing: timing.seconds)
+    return DomainDecompositionOptimization(best_mask=best.mask, timings=tuple(timings))
+
+
+def _validate_masks(masks: Iterable[Mask], valid_masks: set[Mask]) -> set[Mask]:
+    selected = set()
+    for mask in masks:
+        normalized = tuple(mask)
+        if len(normalized) != 3 or not all(isinstance(value, bool) for value in normalized):
+            raise ValueError(f"invalid decomposition mask: {mask!r}")
+        if normalized not in valid_masks:
+            raise ValueError(f"decomposition mask is not valid for this grid/MPI size: {mask!r}")
+        selected.add(normalized)
+    return selected
+
+
+def _barrier(comm) -> None:
+    if comm.Get_size() > 1:
+        comm.Barrier()
+
+
+def _global_max(comm, value: float) -> float:
+    if comm.Get_size() == 1:
+        return value
+    return float(comm.allreduce(value, op=MPI.MAX))

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -6,8 +6,6 @@ anything about the model: the caller supplies a function which performs one
 step for a given mask.
 """
 
-from __future__ import annotations
-
 import itertools
 import time
 from dataclasses import dataclass
@@ -38,6 +36,8 @@ class DomainDecompositionOptimization:
 def candidate_masks(
     num_elements: tuple[int, int, int],
     comm_size: int,
+    *,
+    min_local_elements: int = 1,
 ) -> tuple[Mask, ...]:
     """Return valid non-empty ``mpi_dims_mask`` candidates.
 
@@ -51,6 +51,8 @@ def candidate_masks(
         raise ValueError("num_elements must contain exactly three dimensions")
     if comm_size < 1:
         raise ValueError("comm_size must be positive")
+    if min_local_elements < 1:
+        raise ValueError("min_local_elements must be positive")
     if any(int(n) <= 0 for n in num_elements):
         raise ValueError("num_elements must contain positive values")
     if int(comm_size) > num_elements[0] * num_elements[1] * num_elements[2]:
@@ -67,7 +69,10 @@ def candidate_masks(
         # ``compute_dims`` accepts a process grid whose local block would have
         # zero cells in a short direction.  FEEC discretization cannot use
         # such a grid, so reject it here before invoking the user callback.
-        if any(p > n or block < 1 for p, n, block in zip(nprocs, num_elements, blocksizes)):
+        if any(
+            p > n or block < min_local_elements
+            for p, n, block in zip(nprocs, num_elements, blocksizes)
+        ):
             continue
         masks.append(mask)
 
@@ -80,6 +85,7 @@ def optimize_domain_decomposition(
     *,
     comm=None,
     masks: Iterable[Mask] | None = None,
+    min_local_elements: int = 1,
     warmups: int = 1,
     repetitions: int = 3,
 ) -> DomainDecompositionOptimization:
@@ -120,7 +126,13 @@ def optimize_domain_decomposition(
     if comm is None:
         comm = MPI.COMM_WORLD
     comm_size = comm.Get_size()
-    valid_masks = set(candidate_masks(num_elements, comm_size))
+    valid_masks = set(
+        candidate_masks(
+            num_elements,
+            comm_size,
+            min_local_elements=min_local_elements,
+        )
+    )
     selected_masks = tuple(valid_masks if masks is None else _validate_masks(masks, valid_masks))
     if not selected_masks:
         raise ValueError("no valid decomposition masks were supplied")

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -16,7 +16,11 @@ from feectools.ddm.partition import compute_dims
 
 Mask = tuple[bool, bool, bool]
 LocalMinimum = int | tuple[int, int, int]
-MaskPattern = tuple[bool | Literal["auto"], bool | Literal["auto"], bool | Literal["auto"]]
+MaskPattern = tuple[
+    bool | int | Literal["auto"],
+    bool | int | Literal["auto"],
+    bool | int | Literal["auto"],
+]
 
 
 @dataclass(frozen=True)
@@ -73,7 +77,14 @@ def candidate_masks(
         if not any(mask):
             continue
         if pattern is not None and any(
-            expected != "auto" and value != expected
+            isinstance(expected, bool) and value != expected
+            for value, expected in zip(mask, pattern)
+        ):
+            continue
+        if pattern is not None and any(
+            isinstance(expected, int)
+            and not isinstance(expected, bool)
+            and ((expected > 1 and not value) or (expected == 1 and value))
             for value, expected in zip(mask, pattern)
         ):
             continue
@@ -88,6 +99,13 @@ def candidate_masks(
         if any(
             p > n or block < minimum
             for p, n, block, minimum in zip(nprocs, num_elements, blocksizes, local_minimum)
+        ):
+            continue
+        if pattern is not None and any(
+            isinstance(expected, int)
+            and not isinstance(expected, bool)
+            and nproc != expected
+            for nproc, expected in zip(nprocs, pattern)
         ):
             continue
         masks.append(mask)
@@ -128,6 +146,12 @@ def optimize_domain_decomposition(
         Minimum number of elements in every local block. This can be one
         integer for all directions or a three-tuple for direction-specific
         requirements. For FEEC grids, pass the spline degree tuple.
+    mask_pattern
+        Optional per-direction constraint. Boolean entries fix whether a
+        direction may be decomposed, positive integers require an exact
+        process-grid extent, and ``"auto"`` lets the optimizer vary it. For
+        example, ``(1, "auto", "auto")`` requires one process in the first
+        direction.
     mask_pattern
         Optional per-direction constraint. Use ``True`` or ``False`` to fix a
         direction and ``"auto"`` to let the optimizer vary it, e.g.
@@ -200,8 +224,11 @@ def _normalize_mask_pattern(mask_pattern: MaskPattern | None) -> MaskPattern | N
         return None
     if len(mask_pattern) != 3:
         raise ValueError("mask_pattern must contain exactly three dimensions")
-    if not all(value in (True, False, "auto") for value in mask_pattern):
-        raise ValueError("mask_pattern entries must be True, False, or 'auto'")
+    if not all(
+        value == "auto" or isinstance(value, bool) or isinstance(value, int) and value >= 1
+        for value in mask_pattern
+    ):
+        raise ValueError("mask_pattern entries must be True, False, a positive integer, or 'auto'")
     return mask_pattern
 
 

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -61,11 +61,7 @@ def candidate_clone_counts(comm_size: int) -> tuple[int, ...]:
     """Return clone counts that evenly divide the MPI communicator size."""
     if comm_size < 1:
         raise ValueError("comm_size must be positive")
-    return tuple(
-        clones
-        for clones in range(1, comm_size + 1)
-        if comm_size % clones == 0
-    )
+    return tuple(clones for clones in range(1, comm_size + 1) if comm_size % clones == 0)
 
 
 def candidate_masks(
@@ -106,8 +102,7 @@ def candidate_masks(
         if not any(mask):
             continue
         if pattern is not None and any(
-            isinstance(expected, bool) and value != expected
-            for value, expected in zip(mask, pattern)
+            isinstance(expected, bool) and value != expected for value, expected in zip(mask, pattern)
         ):
             continue
         if pattern is not None and any(
@@ -126,14 +121,11 @@ def candidate_masks(
         # grid (the required minimum is normally the spline degree), so reject
         # it here before invoking the user callback.
         if any(
-            p > n or block < minimum
-            for p, n, block, minimum in zip(nprocs, num_elements, blocksizes, local_minimum)
+            p > n or block < minimum for p, n, block, minimum in zip(nprocs, num_elements, blocksizes, local_minimum)
         ):
             continue
         if pattern is not None and any(
-            isinstance(expected, int)
-            and not isinstance(expected, bool)
-            and nproc != expected
+            isinstance(expected, int) and not isinstance(expected, bool) and nproc != expected
             for nproc, expected in zip(nprocs, pattern)
         ):
             continue
@@ -323,8 +315,7 @@ def _normalize_mask_pattern(mask_pattern: MaskPattern | None) -> MaskPattern | N
     if len(mask_pattern) != 3:
         raise ValueError("mask_pattern must contain exactly three dimensions")
     if not all(
-        value == "auto" or isinstance(value, bool) or isinstance(value, int) and value >= 1
-        for value in mask_pattern
+        value == "auto" or isinstance(value, bool) or isinstance(value, int) and value >= 1 for value in mask_pattern
     ):
         raise ValueError("mask_pattern entries must be True, False, a positive integer, or 'auto'")
     return mask_pattern

--- a/src/struphy/topology/domain_decomposition.py
+++ b/src/struphy/topology/domain_decomposition.py
@@ -16,7 +16,6 @@ from typing import Callable, Iterable
 from feectools.ddm.mpi import mpi as MPI
 from feectools.ddm.partition import compute_dims
 
-
 Mask = tuple[bool, bool, bool]
 
 

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -1,7 +1,16 @@
 import pytest
 
 import struphy.topology.domain_decomposition as dd
-from struphy.topology.domain_decomposition import candidate_masks, optimize_domain_decomposition
+from struphy.topology.domain_decomposition import (
+    candidate_clone_counts,
+    candidate_masks,
+    optimize_domain_decomposition,
+    optimize_parallel_configuration,
+)
+
+
+def test_candidate_clone_counts_are_divisors():
+    assert candidate_clone_counts(8) == (1, 2, 4, 8)
 
 
 def test_candidate_masks_are_valid_and_stable():
@@ -118,6 +127,41 @@ def test_optimizer_rejects_invalid_mask():
 def test_candidate_masks_reject_too_many_ranks():
     with pytest.raises(ValueError, match="cannot exceed"):
         candidate_masks((2, 2, 2), 9)
+
+
+def test_parallel_optimizer_selects_clone_count_and_mask(monkeypatch):
+    class Comm:
+        def Get_size(self):
+            return 8
+
+        def Barrier(self):
+            pass
+
+        def allreduce(self, value, op=None):
+            return value
+
+    costs = {
+        (1, (True, True, True)): 0.01,
+        (2, (True, True, False)): 0.002,
+        (4, (True, False, False)): 0.004,
+    }
+    clock = [0.0]
+    monkeypatch.setattr(dd.time, "perf_counter", lambda: clock[0])
+
+    def step(num_clones, mask):
+        clock[0] += costs.get((num_clones, mask), 0.02)
+
+    result = optimize_parallel_configuration(
+        (8, 8, 8),
+        step,
+        comm=Comm(),
+        clone_counts=(1, 2, 4),
+        warmups=0,
+        repetitions=1,
+    )
+
+    assert result.best_num_clones == 2
+    assert result.best_mask == (True, True, False)
 
 
 def test_candidate_masks_reject_empty_short_direction():

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -18,6 +18,22 @@ def test_candidate_masks_are_valid_and_stable():
     )
 
 
+def test_candidate_masks_can_fix_one_direction_and_auto_tune_the_rest():
+    masks = candidate_masks((8, 8, 8), 4, mask_pattern=(True, "auto", "auto"))
+
+    assert masks == (
+        (True, False, False),
+        (True, False, True),
+        (True, True, False),
+        (True, True, True),
+    )
+
+
+def test_candidate_masks_reject_invalid_pattern():
+    with pytest.raises(ValueError, match="True, False, or 'auto'"):
+        candidate_masks((8, 8, 8), 4, mask_pattern=(True, "sometimes", "auto"))
+
+
 def test_optimizer_selects_fastest_candidate(monkeypatch):
     calls = []
     costs = {

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -102,3 +102,14 @@ def test_candidate_masks_reject_empty_short_direction():
         (True, True, False),
         (True, True, True),
     )
+
+
+def test_candidate_masks_can_enforce_feec_minimum_local_size():
+    masks = candidate_masks((128, 16, 1), 16, min_local_elements=(2, 2, 1))
+
+    assert masks == (
+        (True, False, False),
+        (True, False, True),
+        (True, True, False),
+        (True, True, True),
+    )

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -54,10 +54,7 @@ def test_optimizer_selects_fastest_candidate(monkeypatch):
 
 def test_eight_rank_anisotropic_case_can_leave_one_direction_undecomposed(monkeypatch):
     """An anisotropic 3D case can prefer a 2D process grid."""
-    costs = {
-        mask: 0.01
-        for mask in candidate_masks((48, 24, 8), 8)
-    }
+    costs = {mask: 0.01 for mask in candidate_masks((48, 24, 8), 8)}
     costs[(True, True, False)] = 0.001
     clock = [0.0]
 

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -29,9 +29,22 @@ def test_candidate_masks_can_fix_one_direction_and_auto_tune_the_rest():
     )
 
 
+def test_candidate_masks_can_fix_process_count_in_one_direction():
+    masks = candidate_masks((8, 8, 8), 4, mask_pattern=(1, "auto", "auto"))
+
+    assert masks == (
+        (False, False, True),
+        (False, True, False),
+        (False, True, True),
+    )
+
+
 def test_candidate_masks_reject_invalid_pattern():
-    with pytest.raises(ValueError, match="True, False, or 'auto'"):
+    with pytest.raises(ValueError, match="positive integer"):
         candidate_masks((8, 8, 8), 4, mask_pattern=(True, "sometimes", "auto"))
+
+    with pytest.raises(ValueError, match="positive integer"):
+        candidate_masks((8, 8, 8), 4, mask_pattern=(0, "auto", "auto"))
 
 
 def test_optimizer_selects_fastest_candidate(monkeypatch):

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -1,16 +1,50 @@
 import pytest
 
 import struphy.topology.domain_decomposition as dd
+import struphy.topology.autotuning as tuning
 from struphy.topology.domain_decomposition import (
     candidate_clone_counts,
     candidate_masks,
     optimize_domain_decomposition,
     optimize_parallel_configuration,
 )
+from struphy.topology.autotuning import optimize_integer_parameter, search_integer_parameter
 
 
 def test_candidate_clone_counts_are_divisors():
     assert candidate_clone_counts(8) == (1, 2, 4, 8)
+
+
+def test_integer_parameter_optimizer_selects_fastest_value(monkeypatch):
+    clock = [0.0]
+    costs = {0: 0.03, 1: 0.01, 2: 0.02}
+    monkeypatch.setattr(tuning.time, "perf_counter", lambda: clock[0])
+
+    def step(value):
+        clock[0] += costs[value]
+
+    result = optimize_integer_parameter((0, 1, 2), step, warmups=0, repetitions=1)
+
+    assert result.best_value == 1
+
+
+def test_integer_parameter_search_refines_coarse_optimum(monkeypatch):
+    costs = {value: float((value - 5) ** 2) for value in range(11)}
+    clock = [0.0]
+    monkeypatch.setattr(tuning.time, "perf_counter", lambda: clock[0])
+
+    result = search_integer_parameter(
+        0,
+        10,
+        lambda value: clock.__setitem__(0, clock[0] + costs[value]),
+        coarse_step=5,
+        refinement_radius=2,
+        warmups=0,
+        repetitions=1,
+    )
+
+    assert result.best_value == 5
+    assert {timing.value for timing in result.timings} == {0, 3, 4, 5, 6, 7, 10}
 
 
 def test_candidate_masks_are_valid_and_stable():

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -1,14 +1,14 @@
 import pytest
 
-import struphy.topology.domain_decomposition as dd
 import struphy.topology.autotuning as tuning
+import struphy.topology.domain_decomposition as dd
+from struphy.topology.autotuning import optimize_integer_parameter, search_integer_parameter
 from struphy.topology.domain_decomposition import (
     candidate_clone_counts,
     candidate_masks,
     optimize_domain_decomposition,
     optimize_parallel_configuration,
 )
-from struphy.topology.autotuning import optimize_integer_parameter, search_integer_parameter
 
 
 def test_candidate_clone_counts_are_divisors():

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -1,0 +1,107 @@
+import pytest
+
+import struphy.topology.domain_decomposition as dd
+from struphy.topology.domain_decomposition import candidate_masks, optimize_domain_decomposition
+
+
+def test_candidate_masks_are_valid_and_stable():
+    masks = candidate_masks((8, 8, 8), 4)
+
+    assert masks == (
+        (False, False, True),
+        (False, True, False),
+        (True, False, False),
+        (False, True, True),
+        (True, False, True),
+        (True, True, False),
+        (True, True, True),
+    )
+
+
+def test_optimizer_selects_fastest_candidate(monkeypatch):
+    calls = []
+    costs = {
+        (False, False, True): 0.003,
+        (True, True, True): 0.001,
+    }
+    clock = [0.0]
+
+    def fake_perf_counter():
+        return clock[0]
+
+    def step(mask):
+        calls.append(mask)
+        clock[0] += costs[mask]
+
+    monkeypatch.setattr(dd.time, "perf_counter", fake_perf_counter)
+
+    result = optimize_domain_decomposition(
+        (8, 8, 8),
+        step,
+        masks=costs,
+        warmups=0,
+        repetitions=1,
+    )
+
+    assert result.best_mask == (True, True, True)
+    assert len(result.timings) == 2
+    assert set(calls) == set(costs)
+
+    baseline = next(t.seconds for t in result.timings if t.mask == (False, False, True))
+    best = next(t.seconds for t in result.timings if t.mask == (True, True, True))
+    assert baseline / best == pytest.approx(3.0)
+
+
+def test_eight_rank_anisotropic_case_can_leave_one_direction_undecomposed(monkeypatch):
+    """An anisotropic 3D case can prefer a 2D process grid."""
+    costs = {
+        mask: 0.01
+        for mask in candidate_masks((48, 24, 8), 8)
+    }
+    costs[(True, True, False)] = 0.001
+    clock = [0.0]
+
+    monkeypatch.setattr(dd.time, "perf_counter", lambda: clock[0])
+
+    def step(mask):
+        clock[0] += costs[mask]
+
+    result = optimize_domain_decomposition(
+        (48, 24, 8),
+        step,
+        comm=dd.MPI.COMM_WORLD,
+        warmups=0,
+        repetitions=1,
+    )
+
+    assert result.best_mask == (True, True, False)
+    assert result.best_mask != (True, True, True)
+
+
+def test_optimizer_rejects_invalid_mask():
+    with pytest.raises(ValueError, match="not valid"):
+        optimize_domain_decomposition(
+            (8, 8, 8),
+            lambda mask: None,
+            masks=((False, False, False),),
+            warmups=0,
+            repetitions=1,
+        )
+
+
+def test_candidate_masks_reject_too_many_ranks():
+    with pytest.raises(ValueError, match="cannot exceed"):
+        candidate_masks((2, 2, 2), 9)
+
+
+def test_candidate_masks_reject_empty_short_direction():
+    masks = candidate_masks((16, 64, 1), 8)
+
+    assert masks == (
+        (False, True, False),
+        (True, False, False),
+        (False, True, True),
+        (True, False, True),
+        (True, True, False),
+        (True, True, True),
+    )

--- a/src/struphy/topology/tests/test_domain_decomposition.py
+++ b/src/struphy/topology/tests/test_domain_decomposition.py
@@ -37,14 +37,12 @@ def test_integer_parameter_search_refines_coarse_optimum(monkeypatch):
         0,
         10,
         lambda value: clock.__setitem__(0, clock[0] + costs[value]),
-        coarse_step=5,
-        refinement_radius=2,
         warmups=0,
         repetitions=1,
     )
 
     assert result.best_value == 5
-    assert {timing.value for timing in result.timings} == {0, 3, 4, 5, 6, 7, 10}
+    assert len(result.timings) <= 8
 
 
 def test_candidate_masks_are_valid_and_stable():

--- a/src/struphy/topology/tests/test_sorting_frequency.py
+++ b/src/struphy/topology/tests/test_sorting_frequency.py
@@ -1,0 +1,27 @@
+"""Example of selecting a particle sorting frequency empirically."""
+
+import struphy.topology.autotuning as tuning
+from struphy.topology import optimize_sorting_frequency
+
+
+def test_sorting_frequency_tuner_finds_fastest_candidate(monkeypatch):
+    """A fixed workload with a known sorting tradeoff selects frequency five."""
+    # The callback stands in for one fixed simulation segment. In a real
+    # benchmark it constructs a fresh Simulation with
+    # SortingParameters(sorting_frequency=frequency) and runs that segment.
+    measured_costs = {0: 0.030, 1: 0.080, 2: 0.045, 5: 0.020, 10: 0.025}
+    clock = [0.0]
+    monkeypatch.setattr(tuning.time, "perf_counter", lambda: clock[0])
+
+    def run_segment(frequency):
+        clock[0] += measured_costs[frequency]
+
+    result = optimize_sorting_frequency(
+        (0, 1, 2, 5, 10),
+        run_segment,
+        warmups=0,
+        repetitions=1,
+    )
+
+    assert result.best_value == 5
+    assert min(result.timings, key=lambda timing: timing.seconds).value == 5


### PR DESCRIPTION
Usually, it seems like using `(True, True, True)` is the most efficient domain decomposition. But sometimes it isn't, for example when the number of elements in some direction is small. With this PR, I am trying out some automatic parallelization strategies. It's still a bit experimental.

The main idea is to run 1 timestep (or a few timesteps?) with a specific configuration, time it, then compare it to other configurations.

What could be automatically chosen?

- Domain decomposition in each direction.
- Number of domain clones
- Particle sorting frequency
- Sorting-box layout
- 