### PR TITLE
Enable setting log file with environment variable

### DIFF
--- a/profiling/profiling_job.py
+++ b/profiling/profiling_job.py
@@ -184,7 +184,12 @@ class ProfilingCase:
             f'echo "Running {self.label} with {ntasks} MPI ranks"',
             f'cd "{output_root}"',
             # The run's log lives next to its output, so each run keeps its own record
-            # instead of sharing the driver's terminal or the SLURM log.
+            # instead of sharing the driver's terminal or the SLURM log. STRUPHY_LOG_FILE
+            # is needed on top of the shared cwd above: several rank-count runs of the same
+            # case share `output_root` as their cwd (often concurrently, as separate SLURM
+            # jobs), and struphy's default relative "struphy.log" would otherwise resolve to
+            # the same file for all of them, racing on log rotation across processes.
+            f'STRUPHY_LOG_FILE="{sim_dir / "struphy.log"}" '
             f'{self.launcher} -n {ntasks} {python} {self.params_source} {flags} > "{sim_dir / "struphy.out"}" 2>&1',
             "",
             'echo "----------------------------------------"',

--- a/src/struphy/__init__.py
+++ b/src/struphy/__init__.py
@@ -57,7 +57,11 @@ config = {
             "class": "logging.handlers.RotatingFileHandler",
             "level": "DEBUG",
             "formatter": "detailed",
-            "filename": "struphy.log",
+            # Overridable via STRUPHY_LOG_FILE so processes sharing a cwd (e.g. several
+            # profiling jobs launched from the same case directory) don't rotate the
+            # same file concurrently -- RotatingFileHandler's rollover isn't safe across
+            # separate OS processes and races with FileNotFoundError when they collide.
+            "filename": os.environ.get("STRUPHY_LOG_FILE", "struphy.log"),
             "maxBytes": 10000,
             "backupCount": 3,
         },


### PR DESCRIPTION
This fixes a race condition when multiple runs are executed at the same time in the same workign directory since all of them try to write to the same `struphy.log` file.

You can now set the log file by editing the `STRUPHY_LOG_FILE` environment variable.