### PR TITLE
Improve docstring helpers

### DIFF
--- a/src/struphy/fields_background/base.py
+++ b/src/struphy/fields_background/base.py
@@ -7,7 +7,19 @@ import cunumpy as xp
 from matplotlib import pyplot as plt
 from pyevtk.hl import gridToVTK
 
+try:
+    from IPython.display import HTML, display
+except ImportError:
+
+    def HTML(data):
+        return data
+
+    def display(*objects, **kwargs):
+        return objects[0] if objects else None
+
+
 from struphy.geometry.base import Domain
+from struphy.utils.docstring_converter import rst_to_html, rst_to_latex, rst_to_markdown
 from struphy.utils.utils import (
     __class_with_params_repr_no_defaults__,
     __dataclass_repr_no_defaults__,
@@ -118,6 +130,28 @@ class FluidEquilibrium(metaclass=ABCMeta):
     @property
     def is_default(self):
         return all_class_params_are_default(self)
+
+    forced_heading_level = 5
+
+    @classmethod
+    def _doc_text(cls) -> str:
+        return cls.__doc__ if cls.__doc__ else "Description not available for this equilibrium."
+
+    @classmethod
+    def doc_html(cls) -> str:
+        return rst_to_html(cls._doc_text(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def doc_markdown(cls) -> str:
+        return rst_to_markdown(cls._doc_text())
+
+    @classmethod
+    def doc_latex(cls) -> str:
+        return rst_to_latex(cls._doc_text())
+
+    @classmethod
+    def doc(cls):
+        return display(HTML(cls.doc_html()))
 
     ###########################
     # Vector-valued callables #

--- a/src/struphy/geometry/base.py
+++ b/src/struphy/geometry/base.py
@@ -14,10 +14,22 @@ from pyvista import Plotter, StructuredGrid
 from scipy.sparse import csc_matrix, kron
 from scipy.sparse.linalg import splu, spsolve
 
+try:
+    from IPython.display import HTML, display
+except ImportError:
+
+    def HTML(data):
+        return data
+
+    def display(*objects, **kwargs):
+        return objects[0] if objects else None
+
+
 import struphy.bsplines.bsplines as bsp
 from struphy.geometry import evaluation_kernels, transform_kernels
 from struphy.kernel_arguments.pusher_args_kernels import DomainArguments
 from struphy.linear_algebra import linalg_kron
+from struphy.utils.docstring_converter import rst_to_html, rst_to_latex, rst_to_markdown
 from struphy.utils.utils import __class_with_params_repr_no_defaults__, all_class_params_are_default, all_subclasses
 
 logger = logging.getLogger("struphy")
@@ -303,6 +315,28 @@ class Domain(metaclass=DomainMeta):
     @property
     def is_default(self):
         return all_class_params_are_default(self)
+
+    forced_heading_level = 5
+
+    @classmethod
+    def _doc_text(cls) -> str:
+        return cls.__doc__ if cls.__doc__ else "Description not available for this domain."
+
+    @classmethod
+    def doc_html(cls) -> str:
+        return rst_to_html(cls._doc_text(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def doc_markdown(cls) -> str:
+        return rst_to_markdown(cls._doc_text())
+
+    @classmethod
+    def doc_latex(cls) -> str:
+        return rst_to_latex(cls._doc_text())
+
+    @classmethod
+    def doc(cls):
+        return display(HTML(cls.doc_html()))
 
     @property
     def kind_map(self) -> int:

--- a/src/struphy/initial/base.py
+++ b/src/struphy/initial/base.py
@@ -4,7 +4,19 @@ from typing import Callable
 
 import cunumpy as xp
 
+try:
+    from IPython.display import HTML, display
+except ImportError:
+
+    def HTML(data):
+        return data
+
+    def display(*objects, **kwargs):
+        return objects[0] if objects else None
+
+
 from struphy.io.options import LiteralOptions
+from struphy.utils.docstring_converter import rst_to_html, rst_to_latex, rst_to_markdown
 from struphy.utils.utils import __class_with_params_repr_no_defaults__, check_option
 
 logger = logging.getLogger("struphy")
@@ -82,6 +94,28 @@ class Perturbation(metaclass=ABCMeta):
 
     def __repr_no_defaults__(self):
         return __class_with_params_repr_no_defaults__(self)
+
+    forced_heading_level = 5
+
+    @classmethod
+    def _doc_text(cls) -> str:
+        return cls.__doc__ if cls.__doc__ else "Description not available for this perturbation."
+
+    @classmethod
+    def doc_html(cls) -> str:
+        return rst_to_html(cls._doc_text(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def doc_markdown(cls) -> str:
+        return rst_to_markdown(cls._doc_text())
+
+    @classmethod
+    def doc_latex(cls) -> str:
+        return rst_to_latex(cls._doc_text())
+
+    @classmethod
+    def doc(cls):
+        return display(HTML(cls.doc_html()))
 
     @property
     def given_in_basis(self) -> str:

--- a/src/struphy/models/base.py
+++ b/src/struphy/models/base.py
@@ -33,7 +33,7 @@ from struphy.physics.physics import Units
 from struphy.pic.base import Particles
 from struphy.propagators.base import Propagator
 from struphy.utils.clone_config import CloneConfig
-from struphy.utils.docstring_converter import rst_to_html, rst_to_markdown
+from struphy.utils.docstring_converter import rst_to_html, rst_to_latex, rst_to_markdown
 from struphy.utils.utils import __class_with_params_repr_no_defaults__, all_class_params_are_default, all_subclasses
 
 logger = logging.getLogger("struphy")
@@ -225,6 +225,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
         return rst_to_markdown(cls._info_doc())
 
     @classmethod
+    def info_latex(cls) -> str:
+        return rst_to_latex(cls._info_doc())
+
+    @classmethod
     def info(cls):
         return display(HTML(cls.info_html()))
 
@@ -240,6 +244,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
     @classmethod
     def pde_markdown(cls) -> str:
         return rst_to_markdown(cls._pde_doc())
+
+    @classmethod
+    def pde_latex(cls) -> str:
+        return rst_to_latex(cls._pde_doc())
 
     @classmethod
     def pde(cls):
@@ -265,6 +273,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
         return rst_to_markdown(cls._normalization_doc())
 
     @classmethod
+    def normalization_latex(cls) -> str:
+        return rst_to_latex(cls._normalization_doc())
+
+    @classmethod
     def normalization(cls):
         return display(HTML(cls.normalization_html()))
 
@@ -284,6 +296,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
     @classmethod
     def scalar_quantities_markdown(cls) -> str:
         return rst_to_markdown(cls._scalar_quantities_doc())
+
+    @classmethod
+    def scalar_quantities_latex(cls) -> str:
+        return rst_to_latex(cls._scalar_quantities_doc())
 
     @classmethod
     def scalar_quantities(cls):
@@ -309,6 +325,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
         return rst_to_markdown(cls._discretization_doc())
 
     @classmethod
+    def discretization_latex(cls) -> str:
+        return rst_to_latex(cls._discretization_doc())
+
+    @classmethod
     def discretization(cls):
         return display(HTML(cls.discretization_html()))
 
@@ -332,6 +352,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
         return rst_to_markdown(cls._long_description_doc())
 
     @classmethod
+    def long_description_latex(cls) -> str:
+        return rst_to_latex(cls._long_description_doc())
+
+    @classmethod
     def long_description(cls):
         return display(HTML(cls.long_description_html()))
 
@@ -351,6 +375,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
         return rst_to_markdown(cls._examples_doc())
 
     @classmethod
+    def examples_latex(cls) -> str:
+        return rst_to_latex(cls._examples_doc())
+
+    @classmethod
     def examples(cls):
         return display(HTML(cls.examples_html()))
 
@@ -368,6 +396,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
     @classmethod
     def use_cases_markdown(cls) -> str:
         return rst_to_markdown(cls._use_cases_doc())
+
+    @classmethod
+    def use_cases_latex(cls) -> str:
+        return rst_to_latex(cls._use_cases_doc())
 
     @classmethod
     def use_cases(cls):
@@ -391,6 +423,10 @@ class StruphyModel(metaclass=StruphyModelMeta):
     @classmethod
     def cannot_be_used_for_markdown(cls) -> str:
         return rst_to_markdown(cls._cannot_be_used_for_doc())
+
+    @classmethod
+    def cannot_be_used_for_latex(cls) -> str:
+        return rst_to_latex(cls._cannot_be_used_for_doc())
 
     @classmethod
     def cannot_be_used_for(cls):

--- a/src/struphy/models/base.py
+++ b/src/struphy/models/base.py
@@ -193,7 +193,7 @@ class StruphyModel(metaclass=StruphyModelMeta):
     forced_heading_level = 5
 
     @classmethod
-    def info(cls):
+    def _info_doc(cls) -> str:
         summary = (
             rst_to_html(cls.__doc__).split("Parameters")[0].split("<")[0]
             if cls.__doc__
@@ -202,7 +202,7 @@ class StruphyModel(metaclass=StruphyModelMeta):
         summary = " ".join(summary.split())
         doc = f"**{summary}**\n"
         doc += rf"""To see detailed information on the model, run the following methods:
-        
+
 .. code-block:: python
 
     {cls.name()}.pde()
@@ -214,16 +214,39 @@ class StruphyModel(metaclass=StruphyModelMeta):
     {cls.name()}.use_cases()
     {cls.name()}.cannot_be_used_for()
 """
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
+
+    @classmethod
+    def info_html(cls) -> str:
+        return rst_to_html(cls._info_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def info_markdown(cls) -> str:
+        return rst_to_markdown(cls._info_doc())
+
+    @classmethod
+    def info(cls):
+        return display(HTML(cls.info_html()))
+
+    @classmethod
+    def _pde_doc(cls) -> str:
+        doc_pde = getattr(cls, "doc_pde", None)
+        return doc_pde.__doc__ if doc_pde else """PDE description not available for this model."""
+
+    @classmethod
+    def pde_html(cls) -> str:
+        return rst_to_html(cls._pde_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def pde_markdown(cls) -> str:
+        return rst_to_markdown(cls._pde_doc())
 
     @classmethod
     def pde(cls):
-        doc_pde = getattr(cls, "doc_pde", None)
-        doc = doc_pde.__doc__ if doc_pde else """PDE description not available for this model."""
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return display(HTML(cls.pde_html()))
 
     @classmethod
-    def normalization(cls):
+    def _normalization_doc(cls) -> str:
         doc_normalization = getattr(cls, "doc_normalization", None)
         doc = "**Normalization:**\n"
         doc += (
@@ -231,20 +254,43 @@ class StruphyModel(metaclass=StruphyModelMeta):
             if doc_normalization
             else """Description of normalization not available for this model."""
         )
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
 
     @classmethod
-    def scalar_quantities(cls):
+    def normalization_html(cls) -> str:
+        return rst_to_html(cls._normalization_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def normalization_markdown(cls) -> str:
+        return rst_to_markdown(cls._normalization_doc())
+
+    @classmethod
+    def normalization(cls):
+        return display(HTML(cls.normalization_html()))
+
+    @classmethod
+    def _scalar_quantities_doc(cls) -> str:
         doc_scalar_quantities = getattr(cls, "doc_scalar_quantities", None)
-        doc = (
+        return (
             doc_scalar_quantities.__doc__
             if doc_scalar_quantities
             else """Description of scalar quantities not available for this model."""
         )
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
 
     @classmethod
-    def discretization(cls):
+    def scalar_quantities_html(cls) -> str:
+        return rst_to_html(cls._scalar_quantities_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def scalar_quantities_markdown(cls) -> str:
+        return rst_to_markdown(cls._scalar_quantities_doc())
+
+    @classmethod
+    def scalar_quantities(cls):
+        return display(HTML(cls.scalar_quantities_html()))
+
+    @classmethod
+    def _discretization_doc(cls) -> str:
         doc_discretization = getattr(cls, "doc_discretization", None)
         doc = "**Discretization (Propagators called in sequence):**\n"
         doc += (
@@ -252,10 +298,22 @@ class StruphyModel(metaclass=StruphyModelMeta):
             if doc_discretization
             else """Description of discretization not available for this model."""
         )
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
 
     @classmethod
-    def long_description(cls):
+    def discretization_html(cls) -> str:
+        return rst_to_html(cls._discretization_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def discretization_markdown(cls) -> str:
+        return rst_to_markdown(cls._discretization_doc())
+
+    @classmethod
+    def discretization(cls):
+        return display(HTML(cls.discretization_html()))
+
+    @classmethod
+    def _long_description_doc(cls) -> str:
         doc_long_description = getattr(cls, "doc_long_description", None)
         doc = "**Long description:**\n"
         doc += (
@@ -263,24 +321,60 @@ class StruphyModel(metaclass=StruphyModelMeta):
             if doc_long_description
             else """Long description not available for this model."""
         )
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
 
     @classmethod
-    def examples(cls):
+    def long_description_html(cls) -> str:
+        return rst_to_html(cls._long_description_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def long_description_markdown(cls) -> str:
+        return rst_to_markdown(cls._long_description_doc())
+
+    @classmethod
+    def long_description(cls):
+        return display(HTML(cls.long_description_html()))
+
+    @classmethod
+    def _examples_doc(cls) -> str:
         doc_examples = getattr(cls, "doc_examples", None)
         doc = "**Examples:**\n"
         doc += doc_examples.__doc__ if doc_examples else """Examples not available for this model."""
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
 
     @classmethod
-    def use_cases(cls):
+    def examples_html(cls) -> str:
+        return rst_to_html(cls._examples_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def examples_markdown(cls) -> str:
+        return rst_to_markdown(cls._examples_doc())
+
+    @classmethod
+    def examples(cls):
+        return display(HTML(cls.examples_html()))
+
+    @classmethod
+    def _use_cases_doc(cls) -> str:
         doc_use_cases = getattr(cls, "doc_use_cases", None)
         doc = "**Use cases:**\n"
         doc += doc_use_cases.__doc__ if doc_use_cases else """Description of use cases not available for this model."""
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
 
     @classmethod
-    def cannot_be_used_for(cls):
+    def use_cases_html(cls) -> str:
+        return rst_to_html(cls._use_cases_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def use_cases_markdown(cls) -> str:
+        return rst_to_markdown(cls._use_cases_doc())
+
+    @classmethod
+    def use_cases(cls):
+        return display(HTML(cls.use_cases_html()))
+
+    @classmethod
+    def _cannot_be_used_for_doc(cls) -> str:
         doc_cannot_be_used_for = getattr(cls, "doc_cannot_be_used_for", None)
         doc = "**Cannot be used for:**\n"
         doc += (
@@ -288,7 +382,19 @@ class StruphyModel(metaclass=StruphyModelMeta):
             if doc_cannot_be_used_for
             else """Information on scenarios for which the model is not suitable is not available."""
         )
-        return display(HTML(rst_to_html(doc, forced_heading_level=cls.forced_heading_level)))
+        return doc
+
+    @classmethod
+    def cannot_be_used_for_html(cls) -> str:
+        return rst_to_html(cls._cannot_be_used_for_doc(), forced_heading_level=cls.forced_heading_level)
+
+    @classmethod
+    def cannot_be_used_for_markdown(cls) -> str:
+        return rst_to_markdown(cls._cannot_be_used_for_doc())
+
+    @classmethod
+    def cannot_be_used_for(cls):
+        return display(HTML(cls.cannot_be_used_for_html()))
 
     @classmethod
     def name(cls) -> str:

--- a/src/struphy/utils/docstring_converter.py
+++ b/src/struphy/utils/docstring_converter.py
@@ -1113,6 +1113,165 @@ def rst_to_markdown(rst_text: str) -> str:
     return md
 
 
+def rst_to_latex(rst_text: str) -> str:
+    """
+    Convert RST docstring to LaTeX source.
+
+    This is a lightweight converter (no docutils dependency), covering the common
+    RST patterns used in Struphy docstrings: ``.. math::`` blocks, ``.. code-block::``
+    sections, inline ``:math:``, inline code, ``:class:``/``:meth:``/``:func:``/``:mod:``/
+    ``:attr:``/``:ref:`` roles, bold/italic emphasis, and bullet/numbered lists.
+    It does not escape LaTeX special characters (``%``, ``&``, ``#``, ``_``, ...) in
+    plain text, since docstrings already mix literal LaTeX (inside math blocks) with
+    prose.
+
+    Args:
+        rst_text: RST formatted text
+
+    Returns:
+        LaTeX formatted text
+    """
+    if not rst_text:
+        return ""
+
+    latex = rst_text
+
+    # Extract code-block sections first, restored as verbatim environments.
+    code_blocks = []
+
+    def save_code_block(match):
+        code_content = match.group(1)
+        code_lines = code_content.split("\n")
+        dedented_lines = []
+        for code_line in code_lines:
+            if code_line.startswith("    "):
+                dedented_lines.append(code_line[4:])
+            elif code_line.strip():
+                dedented_lines.append(code_line)
+            else:
+                dedented_lines.append("")
+        cleaned_code = "\n".join(dedented_lines).strip()
+        code_blocks.append(cleaned_code)
+        return f"<!--CODEBLOCK{len(code_blocks) - 1}-->"
+
+    latex = re.sub(r"\.\. code-block::[^\n]*\n(?:\n)?((?:(?:[ \t]+[^\n]*|[ \t]*)\n)*)", save_code_block, latex)
+
+    # Extract .. math:: blocks (already real LaTeX) into equation* environments.
+    math_blocks = []
+
+    def save_math_block(math_content: str):
+        cleaned_lines = [line.strip() for line in math_content.strip().split("\n") if line.strip()]
+        math_blocks.append("\n".join(cleaned_lines))
+        return f"<!--MATHBLOCK{len(math_blocks) - 1}-->"
+
+    latex = _extract_math_directives(latex, save_math_block)
+
+    # Inline :math:`...` -> $...$
+    latex = re.sub(r":math:`([^`]+)`", lambda m: f"${m.group(1)}$", latex)
+
+    # Inline code ``code`` -> \texttt{code}
+    latex = re.sub(r"``([^`]+)``", lambda m: rf"\texttt{{{m.group(1)}}}", latex)
+
+    # :class: references -> \texttt{}
+    latex = re.sub(r":class:`~?([^`]+)`", lambda m: rf"\texttt{{{m.group(1)}}}", latex)
+
+    # :meth:, :func:, :mod:, :attr: -> \texttt{}
+    latex = re.sub(r":(?:meth|func|mod|attr):`~?([^`]+)`", lambda m: rf"\texttt{{{m.group(1)}}}", latex)
+
+    # :ref: -> \textbf{}
+    latex = re.sub(r":ref:`([^`]+)`", lambda m: rf"\textbf{{{m.group(1)}}}", latex)
+
+    # Process line by line for headers and lists (mirrors the structural pass in rst_to_html).
+    lines = latex.split("\n")
+    result_lines = []
+    i = 0
+    list_env = None
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Underlined section headers.
+        if i + 1 < len(lines) and line.strip():
+            next_line = lines[i + 1]
+            if next_line and all(c in '=-~^"#' for c in next_line.strip()) and len(next_line.strip()) > 0:
+                if list_env:
+                    result_lines.append(rf"\end{{{list_env}}}")
+                    list_env = None
+                result_lines.append(rf"\textbf{{{line.strip()}}}\\")
+                i += 2
+                continue
+
+        # Bold header alone on a line (**Text**).
+        bold_header_match = re.match(r"^\*\*([^*]+)\*\*\s*$", line.strip())
+        if bold_header_match:
+            if list_env:
+                result_lines.append(rf"\end{{{list_env}}}")
+                list_env = None
+            result_lines.append(rf"\textbf{{{bold_header_match.group(1)}}}\\")
+            i += 1
+            continue
+
+        # Bullet list items.
+        list_match = re.match(r"^\s*-\s+(.+)$", line)
+        if list_match:
+            if list_env == "enumerate":
+                result_lines.append(r"\end{enumerate}")
+                list_env = None
+            if not list_env:
+                result_lines.append(r"\begin{itemize}")
+                list_env = "itemize"
+            result_lines.append(rf"\item {list_match.group(1)}")
+            i += 1
+            continue
+
+        # Numbered list items.
+        numbered_list_match = re.match(r"^\s*\d+\.\s+(.+)$", line)
+        if numbered_list_match:
+            if list_env == "itemize":
+                result_lines.append(r"\end{itemize}")
+                list_env = None
+            if not list_env:
+                result_lines.append(r"\begin{enumerate}")
+                list_env = "enumerate"
+            result_lines.append(rf"\item {numbered_list_match.group(1)}")
+            i += 1
+            continue
+
+        if not line.strip():
+            if list_env:
+                result_lines.append(rf"\end{{{list_env}}}")
+                list_env = None
+            result_lines.append("")
+            i += 1
+            continue
+
+        if list_env:
+            result_lines.append(rf"\end{{{list_env}}}")
+            list_env = None
+
+        result_lines.append(line)
+        i += 1
+
+    if list_env:
+        result_lines.append(rf"\end{{{list_env}}}")
+
+    latex = "\n".join(result_lines)
+
+    # Remaining inline bold (**text**) and italic (*text*).
+    latex = re.sub(r"\*\*([^*]+)\*\*", lambda m: rf"\textbf{{{m.group(1)}}}", latex)
+    latex = re.sub(r"\*([^*]+)\*", lambda m: rf"\textit{{{m.group(1)}}}", latex)
+
+    # Restore math blocks as display equations.
+    for i, math in enumerate(math_blocks):
+        latex = latex.replace(f"<!--MATHBLOCK{i}-->", f"\\begin{{equation*}}\n{math}\n\\end{{equation*}}")
+
+    # Restore code blocks as verbatim environments.
+    for i, code in enumerate(code_blocks):
+        latex = latex.replace(f"<!--CODEBLOCK{i}-->", f"\\begin{{verbatim}}\n{code}\n\\end{{verbatim}}")
+
+    return latex
+
+
 def auto_convert_docstring(obj):
     """
     Decorator/hook to automatically convert RST docstrings to HTML.


### PR DESCRIPTION
Added `_html`, `_markdown`, `_latex` methods to the model/domain/equilibria/perturbation baseclasses. The `info()`, `pde()`, ... methods remain the same, they just use the `_html` methods and display the code, for example `pde()` is now:

```python
@classmethod
def pde(cls):
    return display(HTML(cls.pde_html()))
```

This is useful for generating latex/markdown/html documents.

## Examples

This means we can now do the following with the `Maxwell` class:

```bash
>>> from struphy.models import Maxwell
>>> print(Maxwell.pde_markdown())
**PDEs solved by model:**

Ampère's law (no current):

$$
\frac{\partial \mathbf{E}}{\partial t} - \nabla \times \mathbf{B} = 0
$$

Faraday's law:

$$
\frac{\partial \mathbf{B}}{\partial t} + \nabla \times \mathbf{E} = 0
$$

>>> print(Maxwell.pde_latex())
\textbf{PDEs solved by model:}\\

Ampère's law (no current):

\begin{equation*}
\frac{\partial \mathbf{E}}{\partial t} - \nabla \times \mathbf{B} = 0
\end{equation*}

Faraday's law:

\begin{equation*}
\frac{\partial \mathbf{B}}{\partial t} + \nabla \times \mathbf{E} = 0
\end{equation*}

>>> print(Maxwell.pde_html())

<h5>PDEs solved by model:</h5>

<p>Ampère's law (no current):</p>

<p><span style="display:block;text-align:center;font-size:1.18em;line-height:1.6;margin:0.35em 0;"><span style="display:inline-flex;flex-direction:column;align-items:center;vertical-align:middle;line-height:1;margin:0 0.08em;"><span style="display:block;padding:0 0.18em;border-bottom:1px solid currentColor;">∂𝐄</span><span style="display:block;padding:0 0.18em;">∂t</span></span> - ∇ × 𝐁 = 0</span></p>

<p>Faraday's law:</p>

<p><span style="display:block;text-align:center;font-size:1.18em;line-height:1.6;margin:0.35em 0;"><span style="display:inline-flex;flex-direction:column;align-items:center;vertical-align:middle;line-height:1;margin:0 0.08em;"><span style="display:block;padding:0 0.18em;border-bottom:1px solid currentColor;">∂𝐁</span><span style="display:block;padding:0 0.18em;">∂t</span></span> + ∇ × 𝐄 = 0</span></p>
```

Examples using the domains:

```bash
>>> from struphy import domains
>>> print(domains.Cuboid.doc_markdown())
Slab geometry (Cartesian coordinates).

$$
F: \begin{bmatrix}\eta_1\\ \eta_2\\ \eta_3\end{bmatrix}\mapsto \begin{bmatrix}
\,\,x= &l_1 + (r_1 - l_1)\,\eta_1\,\,\\
\,\,y= &l_2 + (r_2 - l_2)\,\eta_2\,\,\\
\,\,z= &l_3 + (r_3 - l_3)\,\eta_3\,\,\end{bmatrix}
$$

.. image:: ../../pics/mappings/cuboid.png

Parameters
----------
l1 : float
    Start of x-interval (default: 0.).
r1 : float
    End of x-interval, r1>l1 (default: 1.).
l2 : float
    Start of y-interval (default: 0.).
r2 : float
    End of y-interval, r2>l2 (default: 1.).
l3 : float
    Start of z-interval (default: 0.).
r3 : float
    End of z-interval, r3>l3 (default: 1.).
```

Note that for domains/perturbation/equilibria we just have methods for the entire docstring since it has not been split into subcomponents yet. If we would like to, we can do that in a separate PR.